### PR TITLE
Set default batch size to 100 for Pinecone import to fix serverless import issue

### DIFF
--- a/src/import_vdf/pinecone_import.py
+++ b/src/import_vdf/pinecone_import.py
@@ -9,7 +9,7 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-BATCH_SIZE = 1000  # Set the desired batch size
+BATCH_SIZE = 100  # Set the desired batch size
 
 
 class ImportPinecone(ImportVDF):

--- a/src/import_vdf/pinecone_import.py
+++ b/src/import_vdf/pinecone_import.py
@@ -9,7 +9,7 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-BATCH_SIZE = 100  # Set the desired batch size
+BATCH_SIZE = 1000  # Set the desired batch size
 
 
 class ImportPinecone(ImportVDF):
@@ -65,7 +65,7 @@ class ImportPinecone(ImportVDF):
                             ),
                         )
                 except Exception as e:
-                    tqdm.write(e)
+                    tqdm.write(f"{e}")
                     raise Exception(f"Invalid index name '{index_name}'", e)
             index = self.pc.Index(index_name)
             current_batch_size = BATCH_SIZE


### PR DESCRIPTION
While trying to import data into Pinecone Serverless, I got this error

```
Traceback (most recent call last):
  File "/home/neeraj/codebuddy/vector-io/src/import_vdf/pinecone_import.py", line 163, in upsert_data
    resp = index.upsert(vectors=batch_vectors, namespace=namespace)
  File "/home/neeraj/.local/lib/python3.10/site-packages/pinecone/utils/error_handling.py", line 10, in inner_func
    return func(*args, **kwargs)
  File "/home/neeraj/.local/lib/python3.10/site-packages/pinecone/data/index.py", line 171, in upsert
    return self._upsert_batch(vectors, namespace, _check_type, **kwargs)
  File "/home/neeraj/.local/lib/python3.10/site-packages/pinecone/data/index.py", line 192, in _upsert_batch
    return self._vector_api.upsert(
  File "/home/neeraj/.local/lib/python3.10/site-packages/pinecone/core/client/api_client.py", line 771, in __call__
    return self.callable(self, *args, **kwargs)
  File "/home/neeraj/.local/lib/python3.10/site-packages/pinecone/core/client/api/vector_operations_api.py", line 951, in __upsert
    return self.call_with_http_info(**kwargs)
  File "/home/neeraj/.local/lib/python3.10/site-packages/pinecone/core/client/api_client.py", line 833, in call_with_http_info
    return self.api_client.call_api(
  File "/home/neeraj/.local/lib/python3.10/site-packages/pinecone/core/client/api_client.py", line 408, in call_api
    return self.__call_api(resource_path, method,
  File "/home/neeraj/.local/lib/python3.10/site-packages/pinecone/core/client/api_client.py", line 202, in __call_api
    raise e
  File "/home/neeraj/.local/lib/python3.10/site-packages/pinecone/core/client/api_client.py", line 195, in __call_api
    response_data = self.request(
  File "/home/neeraj/.local/lib/python3.10/site-packages/pinecone/core/client/api_client.py", line 454, in request
    return self.rest_client.POST(url,
  File "/home/neeraj/.local/lib/python3.10/site-packages/pinecone/core/client/rest.py", line 301, in POST
    return self.request("POST", url,
  File "/home/neeraj/.local/lib/python3.10/site-packages/pinecone/core/client/rest.py", line 260, in request
    raise PineconeApiException(http_resp=r)
pinecone.core.client.exceptions.PineconeApiException: (400)
Reason: Bad Request
HTTP response headers: HTTPHeaderDict({'Date': 'Mon, 05 Feb 2024 07:05:58 GMT', 'Content-Type': 'application/json', 'Content-Length': '118', 'Connection': 'keep-alive', 'x-pinecone-request-latency-ms': '20007', 'x-envoy-upstream-service-time': '0', 'server': 'envoy'})
HTTP response body: {"code":11,"message":"Error, message length too large: found 8762704 bytes, the limit is: 4194304 bytes","details":[]}


During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/neeraj/codebuddy/vector-io/src/import_vdf.py", line 213, in <module>
    main()
  File "/home/neeraj/codebuddy/vector-io/src/import_vdf.py", line 196, in main
    import_pinecone(args)
  File "/home/neeraj/codebuddy/vector-io/src/import_vdf.py", line 102, in import_pinecone
    pinecone_import.upsert_data()
  File "/home/neeraj/codebuddy/vector-io/src/import_vdf/pinecone_import.py", line 167, in upsert_data
    tqdm.write(
  File "/home/neeraj/.local/lib/python3.10/site-packages/tqdm/std.py", line 725, in write
    fp.write(s)
AttributeError: 'PineconeApiException' object has no attribute 'write'
```

After changing the default batch size from 1000 to 100, it is working as expected