### PR TITLE
Add Weaviate import and export support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ See the [Contributing](#contributing) section to add support for your favorite v
 | DataStax Astra DB              | ✅     | ✅     |
 | Chroma                         | ✅     | ✅     |
 | Turbopuffer                    | ✅     | ✅     |
+| Weaviate                       | ✅     | ✅     |
 
 </details>
 
@@ -67,7 +68,6 @@ See the [Contributing](#contributing) section to add support for your favorite v
 | Vector Database                | Import | Export |
 |--------------------------------|--------|--------|
 | Azure AI Search                | ❌     | ❌     |
-| Weaviate                       | ❌     | ❌     |
 | MongoDB Atlas                  | ❌     | ❌     |
 | OpenSearch                     | ❌     | ❌     |
 | Apache Cassandra               | ❌     | ❌     |
@@ -251,6 +251,10 @@ options:
 export_vdf -m hkunlp/instructor-xl --push_to_hub pinecone --environment gcp-starter
 
 import_vdf -d /path/to/vdf/dataset milvus
+
+export_vdf weaviate --url http://localhost:8080 --classes MyCollection
+
+import_vdf -d /path/to/vdf/dataset weaviate --url http://localhost:8080
 
 reembed_vdf -d /path/to/vdf/dataset -m sentence-transformers/all-MiniLM-L6-v2 -t title
 ```

--- a/docs/export_vdf_weaviate_help.txt
+++ b/docs/export_vdf_weaviate_help.txt
@@ -1,0 +1,22 @@
+Help for 'export_vdf weaviate':
+usage: export_vdf weaviate [-h] [-u URL] [--api_key API_KEY]
+                           [--deployment {local,cloud,custom}]
+                           [--grpc_port GRPC_PORT]
+                           [--grpc_secure | --no-grpc_secure] [-c CLASSES]
+                           [--batch_size BATCH_SIZE]
+
+options:
+  -h, --help            show this help message and exit
+  -u URL, --url URL     URL of Weaviate instance
+  --api_key API_KEY     Weaviate API key
+  --deployment {local,cloud,custom}
+                        Weaviate deployment type. Inferred from --url by
+                        default.
+  --grpc_port GRPC_PORT
+                        gRPC port for local/custom Weaviate instances
+  --grpc_secure, --no-grpc_secure
+                        Use TLS for gRPC custom connections
+  -c CLASSES, --classes CLASSES
+                        Classes to export (comma-separated)
+  --batch_size BATCH_SIZE
+                        Batch size for writing exported objects to parquet

--- a/docs/import_vdf_weaviate_help.txt
+++ b/docs/import_vdf_weaviate_help.txt
@@ -1,0 +1,17 @@
+Help for 'import_vdf weaviate':
+usage: import_vdf weaviate [-h] [-u URL] [--api_key API_KEY]
+                           [--deployment {local,cloud,custom}]
+                           [--grpc_port GRPC_PORT]
+                           [--grpc_secure | --no-grpc_secure]
+
+options:
+  -h, --help            show this help message and exit
+  -u URL, --url URL     URL of Weaviate instance
+  --api_key API_KEY     Weaviate API key
+  --deployment {local,cloud,custom}
+                        Weaviate deployment type. Inferred from --url by
+                        default.
+  --grpc_port GRPC_PORT
+                        gRPC port for local/custom Weaviate instances
+  --grpc_secure, --no-grpc_secure
+                        Use TLS for gRPC custom connections

--- a/src/vdf_io/export_vdf/weaviate_export.py
+++ b/src/vdf_io/export_vdf/weaviate_export.py
@@ -1,15 +1,28 @@
 import os
+import json
+import argparse
 
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
 from tqdm import tqdm
-import weaviate
 
+from vdf_io.constants import DEFAULT_BATCH_SIZE, ID_COLUMN
 from vdf_io.export_vdf.vdb_export_cls import ExportVDB
 from vdf_io.names import DBNames
 from vdf_io.util import set_arg_from_input, set_arg_from_password
-
-# Set these environment variables
-URL = os.getenv("YOUR_WCS_URL")
-APIKEY = os.getenv("YOUR_WCS_API_KEY")
+from vdf_io.weaviate_util import (
+    collection_count,
+    connect_to_weaviate,
+    find_distance_metric,
+    get_collection_config,
+    is_weaviate_cloud_url,
+    list_collection_names,
+    normalize_vector_map,
+    sanitize_properties,
+    to_plain_dict,
+    use_collection,
+)
 
 
 class ExportWeaviate(ExportVDB):
@@ -21,10 +34,34 @@ class ExportWeaviate(ExportVDB):
             cls.DB_NAME_SLUG, help="Export data from Weaviate"
         )
 
-        parser_weaviate.add_argument("--url", type=str, help="URL of Weaviate instance")
+        parser_weaviate.add_argument(
+            "-u", "--url", type=str, help="URL of Weaviate instance"
+        )
         parser_weaviate.add_argument("--api_key", type=str, help="Weaviate API key")
         parser_weaviate.add_argument(
-            "--classes", type=str, help="Classes to export (comma-separated)"
+            "--deployment",
+            choices=["local", "cloud", "custom"],
+            help="Weaviate deployment type. Inferred from --url by default.",
+        )
+        parser_weaviate.add_argument(
+            "--grpc_port",
+            type=int,
+            help="gRPC port for local/custom Weaviate instances",
+        )
+        parser_weaviate.add_argument(
+            "--grpc_secure",
+            help="Use TLS for gRPC custom connections",
+            default=None,
+            action=argparse.BooleanOptionalAction,
+        )
+        parser_weaviate.add_argument(
+            "-c", "--classes", type=str, help="Classes to export (comma-separated)"
+        )
+        parser_weaviate.add_argument(
+            "--batch_size",
+            type=int,
+            help="Batch size for writing exported objects to parquet",
+            default=DEFAULT_BATCH_SIZE,
         )
 
     @classmethod
@@ -32,19 +69,39 @@ class ExportWeaviate(ExportVDB):
         set_arg_from_input(
             args,
             "url",
-            "Enter the URL of Weaviate instance: ",
+            "Enter the URL of Weaviate instance (default: 'http://localhost:8080'): ",
             str,
+            "http://localhost:8080",
         )
-        set_arg_from_password(
+        if args.get("deployment") == "cloud" or is_weaviate_cloud_url(
+            args.get("url")
+        ):
+            set_arg_from_password(
+                args,
+                "api_key",
+                "Enter the Weaviate API key: ",
+                "WEAVIATE_API_KEY",
+            )
+        else:
+            if os.getenv("WEAVIATE_API_KEY"):
+                args["api_key"] = os.getenv("WEAVIATE_API_KEY")
+            set_arg_from_input(
+                args,
+                "api_key",
+                "Enter the Weaviate API key (hit return if auth is disabled): ",
+                str,
+                "DO_NOT_PROMPT",
+                env_var="WEAVIATE_API_KEY",
+            )
+        set_arg_from_input(
             args,
-            "api_key",
-            "Enter the Weaviate API key: ",
-            "WEAVIATE_API_KEY",
+            "batch_size",
+            f"Enter the export batch size (default: {DEFAULT_BATCH_SIZE}): ",
+            int,
+            DEFAULT_BATCH_SIZE,
         )
         weaviate_export = ExportWeaviate(args)
-        weaviate_export.all_classes = list(
-            weaviate_export.client.collections.list_all().keys()
-        )
+        weaviate_export.all_classes = weaviate_export.get_all_index_names()
         set_arg_from_input(
             weaviate_export.args,
             "classes",
@@ -55,35 +112,118 @@ class ExportWeaviate(ExportVDB):
         weaviate_export.get_data()
         return weaviate_export
 
-    # Connect to a WCS instance
     def __init__(self, args):
         super().__init__(args)
-        self.client = weaviate.connect_to_wcs(
-            cluster_url=self.args["url"],
-            auth_credentials=weaviate.auth.AuthApiKey(self.args["api_key"]),
-            skip_init_checks=True,
-        )
+        self.client = connect_to_weaviate(self.args)
+
+    def get_all_index_names(self):
+        return list_collection_names(self.client)
 
     def get_index_names(self):
         if self.args.get("classes") is None:
-            return self.all_classes
+            return self.get_all_index_names()
         else:
             input_classes = self.args["classes"].split(",")
-            if set(input_classes) - set(self.all_classes):
+            all_classes = self.get_all_index_names()
+            if set(input_classes) - set(all_classes):
                 tqdm.write(
-                    f"These classes are not present in the Weaviate instance: {set(input_classes) - set(self.all_classes)}"
+                    f"These classes are not present in the Weaviate instance: {set(input_classes) - set(all_classes)}"
                 )
-            return [c for c in self.all_classes if c in input_classes]
+            return [c for c in all_classes if c in input_classes]
 
     def get_data(self):
-        # Get all objects of a class
+        index_metas = {}
         index_names = self.get_index_names()
-        for class_name in index_names:
-            collection = self.client.collections.get(class_name)
-            response = collection.aggregate.over_all(total_count=True)
-            print(f"{response.total_count=}")
+        for class_name in tqdm(index_names, desc="Exporting Weaviate classes"):
+            index_metas[class_name] = self.get_data_for_collection(class_name)
 
-            # objects = self.client.query.get(
-            #     wvq.Objects(wvq.Class(class_name)).with_limit(1000)
-            # )
-            # print(objects)
+        self.file_structure.append(os.path.join(self.vdf_directory, "VDF_META.json"))
+        internal_metadata = self.get_basic_vdf_meta(index_metas)
+        meta_text = json.dumps(internal_metadata.model_dump(), indent=4)
+        tqdm.write(meta_text)
+        with open(os.path.join(self.vdf_directory, "VDF_META.json"), "w") as json_file:
+            json_file.write(meta_text)
+        return True
+
+    def get_data_for_collection(self, class_name):
+        collection = use_collection(self.client, class_name)
+        total = collection_count(collection)
+        collection_config = get_collection_config(collection)
+        vectors_directory = self.create_vec_dir(class_name)
+        batch_size = self.args.get("batch_size") or DEFAULT_BATCH_SIZE
+        vector_columns = []
+        rows = []
+        num_vectors_exported = 0
+        dimensions = -1
+
+        for item in tqdm(
+            collection.iterator(include_vector=True),
+            total=total,
+            desc=f"Exporting {class_name}",
+        ):
+            row = self._item_to_row(item, vector_columns)
+            if row is None:
+                continue
+            if dimensions == -1:
+                dimensions = self._first_vector_dimension(row, vector_columns)
+            rows.append(row)
+            if len(rows) >= batch_size:
+                num_vectors_exported += self._save_rows_to_parquet(
+                    rows, vectors_directory
+                )
+                rows = []
+
+        num_vectors_exported += self._save_rows_to_parquet(rows, vectors_directory)
+        self.args["exported_count"] += num_vectors_exported
+        return [
+            self.get_namespace_meta(
+                class_name,
+                vectors_directory,
+                total=total,
+                num_vectors_exported=num_vectors_exported,
+                dim=dimensions,
+                vector_columns=vector_columns or ["vector"],
+                distance=find_distance_metric(collection_config),
+                index_config=to_plain_dict(collection_config),
+            )
+        ]
+
+    def _item_to_row(self, item, vector_columns):
+        vector_map = normalize_vector_map(getattr(item, "vector", None))
+        if not vector_map:
+            tqdm.write(f"Skipping Weaviate object without vector: {item}")
+            return None
+        for vector_column in vector_map.keys():
+            if vector_column not in vector_columns:
+                vector_columns.append(vector_column)
+        properties = sanitize_properties(
+            dict(getattr(item, "properties", {}) or {}),
+            excluded_columns=[ID_COLUMN, *vector_map.keys()],
+        )
+        row = {ID_COLUMN: str(getattr(item, "uuid"))}
+        row.update(properties)
+        row.update(vector_map)
+        return row
+
+    def _first_vector_dimension(self, row, vector_columns):
+        for vector_column in vector_columns:
+            vector = row.get(vector_column)
+            if isinstance(vector, list):
+                return len(vector)
+        return -1
+
+    def _save_rows_to_parquet(self, rows, vectors_directory):
+        if not rows:
+            return 0
+        df = pd.DataFrame(rows)
+        parquet_file = os.path.join(vectors_directory, f"{self.file_ctr}.parquet")
+        df.to_parquet(parquet_file)
+        if not hasattr(self, "parquet_schema"):
+            self.parquet_schema = pq.read_schema(parquet_file)
+        else:
+            self.parquet_schema = pa.unify_schemas(
+                [self.parquet_schema, pq.read_schema(parquet_file)]
+            )
+        self.file_structure.append(parquet_file)
+        self.file_ctr += 1
+        return len(df)

--- a/src/vdf_io/export_vdf/weaviate_export.py
+++ b/src/vdf_io/export_vdf/weaviate_export.py
@@ -73,9 +73,7 @@ class ExportWeaviate(ExportVDB):
             str,
             "http://localhost:8080",
         )
-        if args.get("deployment") == "cloud" or is_weaviate_cloud_url(
-            args.get("url")
-        ):
+        if args.get("deployment") == "cloud" or is_weaviate_cloud_url(args.get("url")):
             set_arg_from_password(
                 args,
                 "api_key",

--- a/src/vdf_io/import_vdf/weaviate_import.py
+++ b/src/vdf_io/import_vdf/weaviate_import.py
@@ -1,0 +1,265 @@
+import argparse
+import os
+from typing import Dict, List
+
+import pandas as pd
+from tqdm import tqdm
+
+from vdf_io.constants import DEFAULT_BATCH_SIZE, INT_MAX
+from vdf_io.import_vdf.vdf_import_cls import ImportVDB
+from vdf_io.meta_types import NamespaceMeta
+from vdf_io.names import DBNames
+from vdf_io.util import (
+    cleanup_df,
+    divide_into_batches,
+    set_arg_from_input,
+    set_arg_from_password,
+)
+from vdf_io.weaviate_util import (
+    batch_context,
+    build_vector_config,
+    connect_to_weaviate,
+    generate_weaviate_uuid,
+    is_weaviate_cloud_url,
+    list_collection_names,
+    sanitize_properties,
+    use_collection,
+)
+
+
+class ImportWeaviate(ImportVDB):
+    DB_NAME_SLUG = DBNames.WEAVIATE
+
+    @classmethod
+    def make_parser(cls, subparsers):
+        parser_weaviate = subparsers.add_parser(
+            cls.DB_NAME_SLUG, help="Import data to Weaviate"
+        )
+        parser_weaviate.add_argument(
+            "-u", "--url", type=str, help="URL of Weaviate instance"
+        )
+        parser_weaviate.add_argument("--api_key", type=str, help="Weaviate API key")
+        parser_weaviate.add_argument(
+            "--deployment",
+            choices=["local", "cloud", "custom"],
+            help="Weaviate deployment type. Inferred from --url by default.",
+        )
+        parser_weaviate.add_argument(
+            "--grpc_port",
+            type=int,
+            help="gRPC port for local/custom Weaviate instances",
+        )
+        parser_weaviate.add_argument(
+            "--grpc_secure",
+            help="Use TLS for gRPC custom connections",
+            default=None,
+            action=argparse.BooleanOptionalAction,
+        )
+
+    @classmethod
+    def import_vdb(cls, args):
+        set_arg_from_input(
+            args,
+            "url",
+            "Enter the URL of Weaviate instance (default: 'http://localhost:8080'): ",
+            str,
+            "http://localhost:8080",
+        )
+        if args.get("deployment") == "cloud" or is_weaviate_cloud_url(
+            args.get("url")
+        ):
+            set_arg_from_password(
+                args,
+                "api_key",
+                "Enter the Weaviate API key: ",
+                "WEAVIATE_API_KEY",
+            )
+        else:
+            if os.getenv("WEAVIATE_API_KEY"):
+                args["api_key"] = os.getenv("WEAVIATE_API_KEY")
+            set_arg_from_input(
+                args,
+                "api_key",
+                "Enter the Weaviate API key (hit return if auth is disabled): ",
+                str,
+                "DO_NOT_PROMPT",
+                env_var="WEAVIATE_API_KEY",
+            )
+        weaviate_import = ImportWeaviate(args)
+        weaviate_import.upsert_data()
+        return weaviate_import
+
+    def __init__(self, args):
+        super().__init__(args)
+        self.client = connect_to_weaviate(self.args)
+
+    def get_all_index_names(self):
+        return list_collection_names(self.client)
+
+    def upsert_data(self):
+        max_hit = False
+        self.total_imported_count = 0
+        indexes_content: Dict[str, List[NamespaceMeta]] = self.vdf_meta["indexes"]
+        if not indexes_content:
+            raise ValueError("No indexes found in VDF_META.json")
+
+        collections = self.get_all_index_names()
+        for index_name, index_meta in tqdm(
+            indexes_content.items(), desc="Importing indexes"
+        ):
+            for namespace_meta in tqdm(index_meta, desc="Importing namespaces"):
+                self.set_dims(namespace_meta, index_name)
+                new_collection_name = index_name + (
+                    f'_{namespace_meta["namespace"]}'
+                    if namespace_meta["namespace"]
+                    else ""
+                )
+                new_collection_name = self.create_new_name(
+                    new_collection_name, collections
+                )
+                vector_column_names, _ = self.get_vector_column_name(
+                    new_collection_name,
+                    namespace_meta,
+                    multi_vector_supported=True,
+                )
+                if new_collection_name not in collections:
+                    self.create_collection(
+                        new_collection_name, vector_column_names, namespace_meta
+                    )
+                    collections.append(new_collection_name)
+
+                collection = use_collection(self.client, new_collection_name)
+                data_path = namespace_meta["data_path"]
+                final_data_path = self.get_final_data_path(data_path)
+                parquet_files = self.get_parquet_files(final_data_path)
+
+                for file in tqdm(parquet_files, desc="Iterating parquet files"):
+                    remaining = (
+                        self.args.get("max_num_rows") or INT_MAX
+                    ) - self.total_imported_count
+                    if remaining <= 0:
+                        max_hit = True
+                        break
+                    file_path = self.get_file_path(final_data_path, file)
+                    df = self.read_parquet_progress(
+                        file_path,
+                        max_num_rows=remaining,
+                    )
+                    df = cleanup_df(df)
+                    batch_size = self.args.get("batch_size") or DEFAULT_BATCH_SIZE
+                    for batch in tqdm(
+                        divide_into_batches(df, batch_size),
+                        desc="Importing batches",
+                        total=max(1, len(df) // batch_size),
+                    ):
+                        remaining = (
+                            self.args.get("max_num_rows") or INT_MAX
+                        ) - self.total_imported_count
+                        if remaining <= 0:
+                            max_hit = True
+                            break
+                        if len(batch) > remaining:
+                            batch = batch.head(remaining)
+                            max_hit = True
+                        imported_count = self.upsert_batch(
+                            collection,
+                            new_collection_name,
+                            batch,
+                            vector_column_names,
+                        )
+                        self.total_imported_count += imported_count
+                    if max_hit:
+                        break
+            if max_hit:
+                tqdm.write(
+                    f"Max rows to be imported {self.args['max_num_rows']} hit. Exiting"
+                )
+                break
+
+        tqdm.write("Data import completed successfully.")
+        self.args["imported_count"] = self.total_imported_count
+
+    def create_collection(self, collection_name, vector_column_names, namespace_meta):
+        vector_config = build_vector_config(
+            vector_column_names,
+            namespace_meta.get("metric"),
+        )
+        create = self.client.collections.create
+        try:
+            create(collection_name, vector_config=vector_config)
+        except TypeError:
+            try:
+                create(name=collection_name, vector_config=vector_config)
+            except TypeError:
+                create(name=collection_name, vectorizer_config=vector_config)
+
+    def upsert_batch(
+        self,
+        collection,
+        collection_name,
+        df,
+        vector_column_names,
+    ):
+        imported_count = 0
+        batch_size = self.args.get("batch_size") or DEFAULT_BATCH_SIZE
+        vector_column_names = [
+            vector_column
+            for vector_column in vector_column_names
+            if vector_column in df.columns
+        ]
+        if not vector_column_names:
+            tqdm.write(f"No vector columns found for collection {collection_name}")
+            return 0
+        df = df.dropna(subset=vector_column_names, how="all")
+        with batch_context(collection, batch_size) as batch:
+            for _, row in df.iterrows():
+                vector_payload = self.get_vector_payload(row, vector_column_names)
+                if vector_payload is None:
+                    continue
+                properties = sanitize_properties(
+                    row.to_dict(),
+                    excluded_columns=[self.id_column, *vector_column_names],
+                )
+                batch.add_object(
+                    properties=properties,
+                    uuid=generate_weaviate_uuid(collection_name, row[self.id_column]),
+                    vector=vector_payload,
+                )
+                imported_count += 1
+                if getattr(batch, "number_errors", 0) > 10:
+                    raise RuntimeError("Stopping Weaviate import after 10 batch errors")
+
+        failed_objects = getattr(collection.batch, "failed_objects", None)
+        if failed_objects:
+            tqdm.write(f"Number of failed Weaviate imports: {len(failed_objects)}")
+            tqdm.write(f"First failed Weaviate import: {failed_objects[0]}")
+        return imported_count
+
+    def get_vector_payload(self, row, vector_column_names):
+        vectors = {}
+        for vector_column in vector_column_names:
+            value = row.get(vector_column)
+            if self.is_missing_vector(value):
+                continue
+            vector = self.extract_vector(value)
+            if vector is not None:
+                vectors[vector_column] = vector
+        if not vectors:
+            return None
+        if list(vectors.keys()) == ["vector"]:
+            return vectors["vector"]
+        return vectors
+
+    def is_missing_vector(self, value):
+        if value is None:
+            return True
+        if isinstance(value, (list, tuple, dict)):
+            return False
+        try:
+            is_missing = pd.isna(value)
+        except (TypeError, ValueError):
+            return False
+        try:
+            return bool(is_missing)
+        except (TypeError, ValueError):
+            return False

--- a/src/vdf_io/import_vdf/weaviate_import.py
+++ b/src/vdf_io/import_vdf/weaviate_import.py
@@ -65,9 +65,7 @@ class ImportWeaviate(ImportVDB):
             str,
             "http://localhost:8080",
         )
-        if args.get("deployment") == "cloud" or is_weaviate_cloud_url(
-            args.get("url")
-        ):
+        if args.get("deployment") == "cloud" or is_weaviate_cloud_url(args.get("url")):
             set_arg_from_password(
                 args,
                 "api_key",

--- a/src/vdf_io/weaviate_util.py
+++ b/src/vdf_io/weaviate_util.py
@@ -1,0 +1,388 @@
+import inspect
+import math
+import re
+from urllib.parse import urlparse
+from uuid import NAMESPACE_URL, UUID, uuid5
+
+
+LOCAL_WEAVIATE_HOSTS = {"localhost", "127.0.0.1", "0.0.0.0", "::1"}
+
+
+def is_weaviate_cloud_url(url):
+    if not url:
+        return False
+    parsed = urlparse(url if "://" in url else f"https://{url}")
+    host = parsed.hostname or ""
+    return host.endswith(".weaviate.cloud") or host.endswith(".weaviate.network")
+
+
+def _call_with_supported_kwargs(func, **kwargs):
+    kwargs = {key: value for key, value in kwargs.items() if value is not None}
+    try:
+        signature = inspect.signature(func)
+    except (TypeError, ValueError):
+        return func(**kwargs)
+    if any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD
+        for parameter in signature.parameters.values()
+    ):
+        return func(**kwargs)
+    supported_kwargs = {
+        key: value for key, value in kwargs.items() if key in signature.parameters
+    }
+    return func(**supported_kwargs)
+
+
+def _get_weaviate_auth(api_key):
+    if not api_key:
+        return None
+    try:
+        from weaviate.classes.init import Auth
+
+        return Auth.api_key(api_key)
+    except (ImportError, AttributeError):
+        import weaviate
+
+        return weaviate.auth.AuthApiKey(api_key)
+
+
+def _parse_weaviate_url(url, default_port=8080):
+    parsed = urlparse(url if "://" in url else f"http://{url}")
+    secure = parsed.scheme == "https"
+    host = parsed.hostname or "localhost"
+    port = parsed.port or (443 if secure else default_port)
+    return host, port, secure
+
+
+def connect_to_weaviate(args):
+    import weaviate
+
+    url = args.get("url") or "http://localhost:8080"
+    deployment = args.get("deployment")
+    api_key = args.get("api_key")
+    host, port, secure = _parse_weaviate_url(url)
+    grpc_port = args.get("grpc_port") or (443 if secure else 50051)
+    grpc_secure = args.get("grpc_secure")
+    if grpc_secure is None:
+        grpc_secure = secure
+
+    auth_credentials = _get_weaviate_auth(api_key)
+    if deployment is None:
+        if is_weaviate_cloud_url(url):
+            deployment = "cloud"
+        elif host in LOCAL_WEAVIATE_HOSTS:
+            deployment = "local"
+        else:
+            deployment = "custom"
+
+    if deployment == "cloud":
+        cloud_connector = getattr(weaviate, "connect_to_weaviate_cloud", None)
+        if cloud_connector is None:
+            cloud_connector = getattr(weaviate, "connect_to_wcs", None)
+        if cloud_connector is None:
+            raise RuntimeError(
+                "Installed weaviate-client does not expose a cloud connection helper"
+            )
+        return _call_with_supported_kwargs(
+            cloud_connector,
+            cluster_url=url,
+            auth_credentials=auth_credentials,
+            skip_init_checks=True,
+        )
+
+    if deployment == "local":
+        return _call_with_supported_kwargs(
+            weaviate.connect_to_local,
+            host=host,
+            port=port,
+            grpc_port=grpc_port,
+            auth_credentials=auth_credentials,
+            skip_init_checks=True,
+        )
+
+    custom_connector = getattr(weaviate, "connect_to_custom", None)
+    if custom_connector is None:
+        raise RuntimeError(
+            "Installed weaviate-client does not expose connect_to_custom"
+        )
+    grpc_host = args.get("grpc_host") or host
+    return _call_with_supported_kwargs(
+        custom_connector,
+        http_host=host,
+        http_port=port,
+        http_secure=secure,
+        grpc_host=grpc_host,
+        grpc_port=grpc_port,
+        grpc_secure=grpc_secure,
+        auth_credentials=auth_credentials,
+        skip_init_checks=True,
+    )
+
+
+def list_collection_names(client):
+    collections = client.collections.list_all()
+    if hasattr(collections, "keys"):
+        return list(collections.keys())
+    return [getattr(collection, "name", str(collection)) for collection in collections]
+
+
+def use_collection(client, collection_name):
+    if hasattr(client.collections, "use"):
+        return client.collections.use(collection_name)
+    return client.collections.get(collection_name)
+
+
+def collection_count(collection):
+    try:
+        return len(collection)
+    except TypeError:
+        pass
+    response = collection.aggregate.over_all(total_count=True)
+    return response.total_count
+
+
+def get_collection_config(collection):
+    if not hasattr(collection, "config"):
+        return None
+    try:
+        return collection.config.get()
+    except Exception:
+        return None
+
+
+def to_plain_dict(value):
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if hasattr(value, "model_dump"):
+        try:
+            return value.model_dump(mode="json")
+        except TypeError:
+            return value.model_dump()
+    if hasattr(value, "dict"):
+        return value.dict()
+    if isinstance(value, dict):
+        return {key: to_plain_dict(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [to_plain_dict(item) for item in value]
+    if hasattr(value, "__dict__"):
+        return {
+            key: to_plain_dict(item)
+            for key, item in vars(value).items()
+            if not key.startswith("_")
+        }
+    return str(value)
+
+
+def find_distance_metric(config):
+    config = to_plain_dict(config)
+
+    def find_distance(value):
+        if isinstance(value, dict):
+            for key in ("distance", "distance_metric", "distanceMetric"):
+                if value.get(key):
+                    return value[key]
+            for nested_value in value.values():
+                distance = find_distance(nested_value)
+                if distance:
+                    return distance
+        elif isinstance(value, list):
+            for nested_value in value:
+                distance = find_distance(nested_value)
+                if distance:
+                    return distance
+        return None
+
+    return find_distance(config)
+
+
+def _to_python_value(value):
+    if hasattr(value, "as_py"):
+        value = value.as_py()
+    elif hasattr(value, "item") and not isinstance(value, (list, tuple, dict)):
+        try:
+            value = value.item()
+        except ValueError:
+            pass
+
+    if not isinstance(value, (list, tuple, dict)):
+        try:
+            is_missing = value != value
+        except (TypeError, ValueError):
+            is_missing = False
+        if isinstance(is_missing, bool) and is_missing:
+            return None
+    if isinstance(value, float) and math.isnan(value):
+        return None
+    if isinstance(value, dict):
+        cleaned = {}
+        for key, item in value.items():
+            item = _to_python_value(item)
+            if item is not None:
+                cleaned[str(key)] = item
+        return cleaned or None
+    if isinstance(value, (list, tuple)):
+        return [_to_python_value(item) for item in value]
+    return value
+
+
+def _sanitize_property_name(name, existing_names):
+    safe_name = re.sub(r"\W+", "_", str(name)).strip("_")
+    if not safe_name:
+        safe_name = "property"
+    if safe_name[0].isdigit():
+        safe_name = f"property_{safe_name}"
+
+    candidate = safe_name
+    suffix = 2
+    while candidate in existing_names:
+        candidate = f"{safe_name}_{suffix}"
+        suffix += 1
+    existing_names.add(candidate)
+    return candidate
+
+
+def sanitize_properties(row, excluded_columns):
+    excluded_columns = set(excluded_columns)
+    properties = {}
+    used_names = set()
+    for key, value in row.items():
+        if key in excluded_columns:
+            continue
+        value = _to_python_value(value)
+        if value is None:
+            continue
+        properties[_sanitize_property_name(key, used_names)] = value
+    return properties
+
+
+def normalize_vector_value(value):
+    if value is None:
+        return None
+    if hasattr(value, "tolist"):
+        value = value.tolist()
+    if isinstance(value, tuple):
+        value = list(value)
+    if isinstance(value, list):
+        return [normalize_vector_value(item) for item in value]
+    return float(value)
+
+
+def normalize_vector_map(vector):
+    if vector is None:
+        return {}
+    if hasattr(vector, "model_dump"):
+        vector = vector.model_dump()
+    elif hasattr(vector, "to_dict"):
+        vector = vector.to_dict()
+    elif hasattr(vector, "__dict__") and not isinstance(vector, (list, tuple, dict)):
+        vector = {
+            key: value
+            for key, value in vars(vector).items()
+            if not key.startswith("_")
+        }
+
+    if isinstance(vector, dict):
+        normalized = {}
+        for name, value in vector.items():
+            vector_value = normalize_vector_value(value)
+            if vector_value is None:
+                continue
+            column_name = "vector" if name in ("", "default", None) else str(name)
+            normalized[column_name] = vector_value
+        return normalized
+
+    return {"vector": normalize_vector_value(vector)}
+
+
+def generate_weaviate_uuid(collection_name, object_id):
+    try:
+        return str(UUID(str(object_id)))
+    except ValueError:
+        return str(uuid5(NAMESPACE_URL, f"vector-io:{collection_name}:{object_id}"))
+
+
+def weaviate_metric_from_vdf(metric):
+    metric = getattr(metric, "value", metric)
+    metric_text = str(metric or "").lower()
+    if "euclid" in metric_text or "l2" in metric_text:
+        return "l2-squared"
+    if "dot" in metric_text or metric_text in {"ip", "inner_product"}:
+        return "dot"
+    if "manhattan" in metric_text or "l1" in metric_text:
+        return "manhattan"
+    return "cosine"
+
+
+def _weaviate_distance_enum(metric):
+    metric = weaviate_metric_from_vdf(metric)
+    try:
+        from weaviate.classes.config import VectorDistances
+    except ImportError:
+        return metric
+    distance_names = {
+        "cosine": "COSINE",
+        "dot": "DOT",
+        "l2-squared": "L2_SQUARED",
+        "manhattan": "MANHATTAN",
+    }
+    return getattr(VectorDistances, distance_names[metric], metric)
+
+
+def _vector_index_config(metric):
+    try:
+        from weaviate.classes.config import Configure
+    except ImportError:
+        return None
+    try:
+        return Configure.VectorIndex.hnsw(
+            distance_metric=_weaviate_distance_enum(metric)
+        )
+    except (AttributeError, TypeError):
+        return None
+
+
+def _self_provided_vector_config(name=None, vector_index_config=None):
+    from weaviate.classes.config import Configure
+
+    kwargs = {}
+    if name is not None:
+        kwargs["name"] = name
+    if vector_index_config is not None:
+        kwargs["vector_index_config"] = vector_index_config
+
+    try:
+        return Configure.Vectors.self_provided(**kwargs)
+    except (AttributeError, TypeError):
+        kwargs.pop("vector_index_config", None)
+        try:
+            return Configure.Vectors.self_provided(**kwargs)
+        except (AttributeError, TypeError):
+            pass
+
+    try:
+        return Configure.NamedVectors.none(**kwargs)
+    except (AttributeError, TypeError):
+        if name is not None:
+            return Configure.NamedVectors.none(name=name)
+        return Configure.Vectorizer.none()
+
+
+def build_vector_config(vector_columns, metric):
+    vector_columns = vector_columns or ["vector"]
+    vector_index_config = _vector_index_config(metric)
+    if vector_columns == ["vector"]:
+        return _self_provided_vector_config(vector_index_config=vector_index_config)
+    return [
+        _self_provided_vector_config(
+            name=vector_column, vector_index_config=vector_index_config
+        )
+        for vector_column in vector_columns
+    ]
+
+
+def batch_context(collection, batch_size):
+    if hasattr(collection.batch, "fixed_size"):
+        return collection.batch.fixed_size(batch_size=batch_size)
+    if hasattr(collection.batch, "dynamic"):
+        return collection.batch.dynamic()
+    return collection.batch

--- a/src/vdf_io/weaviate_util.py
+++ b/src/vdf_io/weaviate_util.py
@@ -276,9 +276,7 @@ def normalize_vector_map(vector):
         vector = vector.to_dict()
     elif hasattr(vector, "__dict__") and not isinstance(vector, (list, tuple, dict)):
         vector = {
-            key: value
-            for key, value in vars(vector).items()
-            if not key.startswith("_")
+            key: value for key, value in vars(vector).items() if not key.startswith("_")
         }
 
     if isinstance(vector, dict):

--- a/tests/test_weaviate_support.py
+++ b/tests/test_weaviate_support.py
@@ -1,0 +1,140 @@
+import unittest
+from types import SimpleNamespace
+
+import pandas as pd
+
+from vdf_io.export_vdf.weaviate_export import ExportWeaviate
+from vdf_io.import_vdf.weaviate_import import ImportWeaviate
+from vdf_io.weaviate_util import (
+    generate_weaviate_uuid,
+    normalize_vector_map,
+    sanitize_properties,
+    weaviate_metric_from_vdf,
+)
+
+
+class FakeBatch:
+    def __init__(self):
+        self.objects = []
+        self.number_errors = 0
+        self.failed_objects = []
+        self.batch_size = None
+
+    def fixed_size(self, batch_size):
+        self.batch_size = batch_size
+        return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def add_object(self, properties, uuid, vector):
+        self.objects.append(
+            {
+                "properties": properties,
+                "uuid": uuid,
+                "vector": vector,
+            }
+        )
+
+
+class FakeCollection:
+    def __init__(self):
+        self.batch = FakeBatch()
+
+
+class WeaviateSupportTests(unittest.TestCase):
+    def test_normalize_vector_map_handles_default_and_named_vectors(self):
+        self.assertEqual(normalize_vector_map([1, 2]), {"vector": [1.0, 2.0]})
+        self.assertEqual(
+            normalize_vector_map({"default": [1, 2], "title": (3, 4)}),
+            {"vector": [1.0, 2.0], "title": [3.0, 4.0]},
+        )
+
+    def test_weaviate_uuid_is_deterministic(self):
+        first_uuid = generate_weaviate_uuid("Article", "row-1")
+        second_uuid = generate_weaviate_uuid("Article", "row-1")
+        self.assertEqual(first_uuid, second_uuid)
+        self.assertEqual(
+            generate_weaviate_uuid("Article", "00000000-0000-0000-0000-000000000001"),
+            "00000000-0000-0000-0000-000000000001",
+        )
+
+    def test_metric_mapping_uses_weaviate_names(self):
+        self.assertEqual(weaviate_metric_from_vdf("Cosine"), "cosine")
+        self.assertEqual(weaviate_metric_from_vdf("Euclid"), "l2-squared")
+        self.assertEqual(weaviate_metric_from_vdf("Dot"), "dot")
+        self.assertEqual(weaviate_metric_from_vdf("Manhattan"), "manhattan")
+
+    def test_sanitize_properties_excludes_vectors_and_ids(self):
+        properties = sanitize_properties(
+            {
+                "id": "row-1",
+                "title vector": [0.1, 0.2],
+                "bad name": "value",
+                "empty": None,
+            },
+            excluded_columns=["id", "title vector"],
+        )
+        self.assertEqual(properties, {"bad_name": "value"})
+
+    def test_export_row_preserves_uuid_as_vdf_id(self):
+        exporter = object.__new__(ExportWeaviate)
+        vector_columns = []
+        item = SimpleNamespace(
+            uuid="00000000-0000-0000-0000-000000000001",
+            properties={"id": "metadata-id", "title": "A"},
+            vector={"default": [0.1, 0.2], "body_vector": [0.3, 0.4]},
+        )
+
+        row = exporter._item_to_row(item, vector_columns)
+
+        self.assertEqual(row["id"], "00000000-0000-0000-0000-000000000001")
+        self.assertEqual(vector_columns, ["vector", "body_vector"])
+        self.assertEqual(row["vector"], [0.1, 0.2])
+        self.assertEqual(row["body_vector"], [0.3, 0.4])
+        self.assertEqual(row["title"], "A")
+
+    def test_import_batch_uses_named_vectors(self):
+        importer = object.__new__(ImportWeaviate)
+        importer.args = {"batch_size": 2}
+        importer.id_column = "id"
+        importer.abnormal_vector_format = False
+        collection = FakeCollection()
+        df = pd.DataFrame(
+            [
+                {
+                    "id": "row-1",
+                    "title": "A",
+                    "title_vector": [0.1, 0.2],
+                    "body_vector": [0.3, 0.4],
+                },
+                {
+                    "id": "row-2",
+                    "title": "B",
+                    "title_vector": [0.5, 0.6],
+                    "body_vector": [0.7, 0.8],
+                },
+            ]
+        )
+
+        imported_count = importer.upsert_batch(
+            collection,
+            "Article",
+            df,
+            ["title_vector", "body_vector"],
+        )
+
+        self.assertEqual(imported_count, 2)
+        self.assertEqual(collection.batch.batch_size, 2)
+        self.assertEqual(
+            collection.batch.objects[0]["vector"],
+            {"title_vector": [0.1, 0.2], "body_vector": [0.3, 0.4]},
+        )
+        self.assertEqual(collection.batch.objects[0]["properties"], {"title": "A"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
/claim #74

## Demo

End-to-end round-trip against a live Weaviate instance (Docker, `semitechnologies/weaviate:1.27.0`):

![Weaviate import/export demo](https://github.com/yasirjama/vector-io/raw/demo-assets/demo.gif)

The recording walks through:

1. Local Weaviate container running on `:8080` (REST) / `:50051` (gRPC)
2. Source class `DemoArticles` — 5 objects, 8-dim vectors, with `title` + `category` properties
3. `python -m vdf_io.export_vdf_cli weaviate -u http://localhost:8080 -c DemoArticles` → produces a `vdf_<timestamp>_<hash>/` directory with `VDF_META.json` and `DemoArticles/1.parquet`
4. `DemoArticles` deleted from Weaviate to prove the import is doing the work
5. `python -m vdf_io.import_vdf_cli -d vdf_… weaviate -u http://localhost:8080` → re-creates `DemoArticles` and pushes all 5 objects back
6. Round-trip verification: all 5 titles, categories, and vector values match the source

Higher-quality MP4 of the same run: <https://github.com/yasirjama/vector-io/raw/demo-assets/demo.mp4>

## Summary
- Completes Weaviate export support with local/cloud/custom connection handling, class selection, object iteration with vectors, batched parquet writes, VDF metadata, and named vector columns.
- Adds Weaviate import support that creates self-provided-vector collections and batches VDF rows into Weaviate, including multiple vector columns as named vectors.
- Documents the Weaviate CLI options and marks Weaviate as supported in the README.

## Why
The existing Weaviate export module was only a partial stub and no matching import implementation existed, so the dynamic adapter could not satisfy the VDF import/export contract for Weaviate.

## Validation
- Static: `PYTHONPATH=src .venv/bin/python -m py_compile src/vdf_io/weaviate_util.py src/vdf_io/export_vdf/weaviate_export.py src/vdf_io/import_vdf/weaviate_import.py tests/test_weaviate_support.py`
- Unit: `PYTHONPATH=src .venv/bin/python -m pytest -q tests/test_weaviate_support.py`
- Parser/vector-config smoke test for `ExportWeaviate`, `ImportWeaviate`, and `build_vector_config` using `weaviate-client==4.21.0`
- **Live Weaviate round-trip** (see demo above): 5-object class exported to VDF parquet, source class deleted, VDF re-imported into Weaviate, all properties and 8-dim vectors verified intact.