### PR TITLE
Add Weaviate import and export support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ See the [Contributing](#contributing) section to add support for your favorite v
 | DataStax Astra DB              | ✅     | ✅     |
 | Chroma                         | ✅     | ✅     |
 | Turbopuffer                    | ✅     | ✅     |
+| Weaviate                       | ✅     | ✅     |
 
 </details>
 
@@ -67,7 +68,6 @@ See the [Contributing](#contributing) section to add support for your favorite v
 | Vector Database                | Import | Export |
 |--------------------------------|--------|--------|
 | Azure AI Search                | ❌     | ❌     |
-| Weaviate                       | ❌     | ❌     |
 | MongoDB Atlas                  | ❌     | ❌     |
 | OpenSearch                     | ❌     | ❌     |
 | Apache Cassandra               | ❌     | ❌     |

--- a/docs/export_vdf_weaviate_help.txt
+++ b/docs/export_vdf_weaviate_help.txt
@@ -1,0 +1,14 @@
+Help for 'export_vdf weaviate':
+usage: export_vdf weaviate [-h] [--url URL] [--api_key API_KEY]
+                           [--classes CLASSES] [--grpc_port GRPC_PORT]
+                           [--skip_init_checks SKIP_INIT_CHECKS]
+
+options:
+  -h, --help            show this help message and exit
+  --url URL             URL of a local or cloud Weaviate instance
+  --api_key API_KEY     Weaviate API key
+  --classes CLASSES     Collections/classes to export (comma-separated)
+  --grpc_port GRPC_PORT
+                        Weaviate gRPC port (default: 50051)
+  --skip_init_checks SKIP_INIT_CHECKS
+                        Skip Weaviate client startup checks (default: True)

--- a/docs/import_vdf_weaviate_help.txt
+++ b/docs/import_vdf_weaviate_help.txt
@@ -1,0 +1,13 @@
+Help for 'import_vdf weaviate':
+usage: import_vdf weaviate [-h] [--url URL] [--api_key API_KEY]
+                           [--grpc_port GRPC_PORT]
+                           [--skip_init_checks SKIP_INIT_CHECKS]
+
+options:
+  -h, --help            show this help message and exit
+  --url URL             URL of a local or cloud Weaviate instance
+  --api_key API_KEY     Weaviate API key
+  --grpc_port GRPC_PORT
+                        Weaviate gRPC port (default: 50051)
+  --skip_init_checks SKIP_INIT_CHECKS
+                        Skip Weaviate client startup checks (default: True)

--- a/src/vdf_io/export_vdf/weaviate_export.py
+++ b/src/vdf_io/export_vdf/weaviate_export.py
@@ -41,7 +41,9 @@ class ExportWeaviate(ExportVDB):
         )
         parser_weaviate.add_argument("--api_key", type=str, help="Weaviate API key")
         parser_weaviate.add_argument(
-            "--classes", type=str, help="Collections/classes to export (comma-separated)"
+            "--classes",
+            type=str,
+            help="Collections/classes to export (comma-separated)",
         )
         parser_weaviate.add_argument(
             "--grpc_port",
@@ -149,7 +151,10 @@ class ExportWeaviate(ExportVDB):
                 vectors_by_column.setdefault(vector_column, {})[object_id] = vector
             metadata[object_id] = dict(getattr(item, "properties", {}) or {})
 
-            if sys.getsizeof(vectors_by_column) + sys.getsizeof(metadata) > DISK_SPACE_LIMIT:
+            if (
+                sys.getsizeof(vectors_by_column) + sys.getsizeof(metadata)
+                > DISK_SPACE_LIMIT
+            ):
                 num_vectors_exported += self.save_weaviate_vectors_to_parquet(
                     vectors_by_column,
                     metadata,

--- a/src/vdf_io/export_vdf/weaviate_export.py
+++ b/src/vdf_io/export_vdf/weaviate_export.py
@@ -1,15 +1,27 @@
+import json
 import os
+import sys
+from typing import Dict, List
 
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
 from tqdm import tqdm
-import weaviate
 
+from vdf_io.constants import DISK_SPACE_LIMIT, ID_COLUMN
 from vdf_io.export_vdf.vdb_export_cls import ExportVDB
+from vdf_io.meta_types import NamespaceMeta
 from vdf_io.names import DBNames
 from vdf_io.util import set_arg_from_input, set_arg_from_password
-
-# Set these environment variables
-URL = os.getenv("YOUR_WCS_URL")
-APIKEY = os.getenv("YOUR_WCS_API_KEY")
+from vdf_io.weaviate_util import (
+    DEFAULT_WEAVIATE_GRPC_PORT,
+    DEFAULT_WEAVIATE_URL,
+    connect_weaviate,
+    get_weaviate_collection,
+    is_local_weaviate_url,
+    list_weaviate_collection_names,
+    serializable_weaviate_config,
+)
 
 
 class ExportWeaviate(ExportVDB):
@@ -21,10 +33,27 @@ class ExportWeaviate(ExportVDB):
             cls.DB_NAME_SLUG, help="Export data from Weaviate"
         )
 
-        parser_weaviate.add_argument("--url", type=str, help="URL of Weaviate instance")
+        parser_weaviate.add_argument(
+            "--url",
+            type=str,
+            help="URL of a local or cloud Weaviate instance",
+            default=DEFAULT_WEAVIATE_URL,
+        )
         parser_weaviate.add_argument("--api_key", type=str, help="Weaviate API key")
         parser_weaviate.add_argument(
-            "--classes", type=str, help="Classes to export (comma-separated)"
+            "--classes", type=str, help="Collections/classes to export (comma-separated)"
+        )
+        parser_weaviate.add_argument(
+            "--grpc_port",
+            type=int,
+            help=f"Weaviate gRPC port (default: {DEFAULT_WEAVIATE_GRPC_PORT})",
+            default=DEFAULT_WEAVIATE_GRPC_PORT,
+        )
+        parser_weaviate.add_argument(
+            "--skip_init_checks",
+            type=bool,
+            help="Skip Weaviate client startup checks (default: True)",
+            default=True,
         )
 
     @classmethod
@@ -32,58 +61,225 @@ class ExportWeaviate(ExportVDB):
         set_arg_from_input(
             args,
             "url",
-            "Enter the URL of Weaviate instance: ",
+            f"Enter the URL of the Weaviate instance (default: '{DEFAULT_WEAVIATE_URL}'): ",
             str,
+            DEFAULT_WEAVIATE_URL,
         )
-        set_arg_from_password(
+        set_arg_from_input(
             args,
-            "api_key",
-            "Enter the Weaviate API key: ",
-            "WEAVIATE_API_KEY",
+            "grpc_port",
+            f"Enter the Weaviate gRPC port (default: {DEFAULT_WEAVIATE_GRPC_PORT}): ",
+            int,
+            DEFAULT_WEAVIATE_GRPC_PORT,
         )
+        if not is_local_weaviate_url(args["url"]):
+            set_arg_from_password(
+                args,
+                "api_key",
+                "Enter the Weaviate API key: ",
+                "WEAVIATE_API_KEY",
+            )
         weaviate_export = ExportWeaviate(args)
-        weaviate_export.all_classes = list(
-            weaviate_export.client.collections.list_all().keys()
-        )
+        weaviate_export.all_classes = weaviate_export.get_all_index_names()
         set_arg_from_input(
             weaviate_export.args,
             "classes",
-            "Enter the name of the classes to export (comma-separated, all will be exported by default): ",
+            "Enter the classes to export (comma-separated, hit return to export all): ",
             str,
             choices=weaviate_export.all_classes,
         )
         weaviate_export.get_data()
         return weaviate_export
 
-    # Connect to a WCS instance
     def __init__(self, args):
         super().__init__(args)
-        self.client = weaviate.connect_to_wcs(
-            cluster_url=self.args["url"],
-            auth_credentials=weaviate.auth.AuthApiKey(self.args["api_key"]),
-            skip_init_checks=True,
-        )
+        self.client = connect_weaviate(args)
 
-    def get_index_names(self):
+    def get_all_index_names(self) -> List[str]:
+        return list_weaviate_collection_names(self.client)
+
+    def get_index_names(self) -> List[str]:
         if self.args.get("classes") is None:
-            return self.all_classes
-        else:
-            input_classes = self.args["classes"].split(",")
-            if set(input_classes) - set(self.all_classes):
-                tqdm.write(
-                    f"These classes are not present in the Weaviate instance: {set(input_classes) - set(self.all_classes)}"
-                )
-            return [c for c in self.all_classes if c in input_classes]
+            return self.get_all_index_names()
+
+        all_classes = getattr(self, "all_classes", self.get_all_index_names())
+        input_classes = self.args["classes"].split(",")
+        missing_classes = set(input_classes) - set(all_classes)
+        if missing_classes:
+            tqdm.write(
+                f"These classes are not present in the Weaviate instance: {missing_classes}"
+            )
+        return [class_name for class_name in all_classes if class_name in input_classes]
 
     def get_data(self):
-        # Get all objects of a class
-        index_names = self.get_index_names()
-        for class_name in index_names:
-            collection = self.client.collections.get(class_name)
-            response = collection.aggregate.over_all(total_count=True)
-            print(f"{response.total_count=}")
+        index_metas: Dict[str, List[NamespaceMeta]] = {}
+        for collection_name in tqdm(self.get_index_names(), desc="Exporting classes"):
+            index_metas[collection_name] = self.get_data_for_collection(collection_name)
 
-            # objects = self.client.query.get(
-            #     wvq.Objects(wvq.Class(class_name)).with_limit(1000)
-            # )
-            # print(objects)
+        self.file_structure.append(os.path.join(self.vdf_directory, "VDF_META.json"))
+        internal_metadata = self.get_basic_vdf_meta(index_metas)
+        meta_text = json.dumps(internal_metadata.model_dump(), indent=4)
+        tqdm.write(meta_text)
+        with open(os.path.join(self.vdf_directory, "VDF_META.json"), "w") as json_file:
+            json_file.write(meta_text)
+        return True
+
+    def get_data_for_collection(self, collection_name):
+        collection = get_weaviate_collection(self.client, collection_name)
+        vectors_directory = self.create_vec_dir(collection_name)
+        index_config = self.get_collection_config(collection)
+
+        vectors_by_column = {}
+        metadata = {}
+        vector_columns = []
+        num_vectors_exported = 0
+
+        for item in tqdm(
+            self.get_collection_iterator(collection),
+            total=self.get_collection_count(collection),
+            desc=f"Exporting {collection_name}",
+        ):
+            object_id = str(item.uuid)
+            object_vectors = self.get_object_vectors(getattr(item, "vector", None))
+            if not object_vectors:
+                continue
+            for vector_column, vector in object_vectors.items():
+                if vector_column not in vector_columns:
+                    vector_columns.append(vector_column)
+                vectors_by_column.setdefault(vector_column, {})[object_id] = vector
+            metadata[object_id] = dict(getattr(item, "properties", {}) or {})
+
+            if sys.getsizeof(vectors_by_column) + sys.getsizeof(metadata) > DISK_SPACE_LIMIT:
+                num_vectors_exported += self.save_weaviate_vectors_to_parquet(
+                    vectors_by_column,
+                    metadata,
+                    vectors_directory,
+                    vector_columns,
+                )
+                vectors_by_column = {}
+                metadata = {}
+
+        if vectors_by_column:
+            num_vectors_exported += self.save_weaviate_vectors_to_parquet(
+                vectors_by_column,
+                metadata,
+                vectors_directory,
+                vector_columns,
+            )
+
+        dim = self.get_first_vector_dim(vectors_by_column)
+        if dim == -1 and hasattr(self, "_last_vector_columns_dim"):
+            dim = self._last_vector_columns_dim
+
+        namespace_meta = self.get_namespace_meta(
+            collection_name,
+            vectors_directory,
+            total=self.get_collection_count(collection),
+            num_vectors_exported=num_vectors_exported,
+            dim=dim,
+            index_config=index_config,
+            vector_columns=vector_columns or ["vector"],
+            distance=self.get_collection_distance(index_config),
+        )
+        self.args["exported_count"] += num_vectors_exported
+        return [namespace_meta]
+
+    def get_collection_iterator(self, collection):
+        try:
+            return collection.iterator(include_vector=True)
+        except TypeError:
+            return collection.iterator()
+
+    def get_collection_count(self, collection):
+        try:
+            return len(collection)
+        except TypeError:
+            response = collection.aggregate.over_all(total_count=True)
+            return response.total_count
+
+    def get_collection_config(self, collection):
+        if hasattr(collection, "config"):
+            try:
+                return serializable_weaviate_config(collection.config.get())
+            except Exception:
+                return None
+        return None
+
+    def get_collection_distance(self, index_config):
+        def find_distance(value):
+            if isinstance(value, dict):
+                if "distance" in value and value["distance"]:
+                    return value["distance"]
+                for nested_value in value.values():
+                    distance = find_distance(nested_value)
+                    if distance:
+                        return distance
+            if isinstance(value, list):
+                for item in value:
+                    distance = find_distance(item)
+                    if distance:
+                        return distance
+            return None
+
+        return find_distance(index_config) or "cosine"
+
+    def get_object_vectors(self, vector):
+        if vector is None:
+            return {}
+        if hasattr(vector, "to_dict"):
+            vector = vector.to_dict()
+        if isinstance(vector, dict):
+            if set(vector.keys()) == {"default"}:
+                return {"vector": vector["default"]}
+            return {
+                str(vector_name): vector_value
+                for vector_name, vector_value in vector.items()
+                if vector_value is not None
+            }
+        return {"vector": vector}
+
+    def get_first_vector_dim(self, vectors_by_column):
+        for vectors in vectors_by_column.values():
+            for vector in vectors.values():
+                if vector is not None:
+                    try:
+                        return len(vector)
+                    except TypeError:
+                        return -1
+        return -1
+
+    def save_weaviate_vectors_to_parquet(
+        self, vectors_by_column, metadata, vectors_directory, vector_columns
+    ):
+        rows_by_id = {}
+        for vector_column, vectors in vectors_by_column.items():
+            for object_id, vector in vectors.items():
+                rows_by_id.setdefault(object_id, {ID_COLUMN: object_id})[
+                    vector_column
+                ] = vector
+                if vector is not None:
+                    self._last_vector_columns_dim = len(vector)
+
+        for object_id, object_metadata in metadata.items():
+            row = rows_by_id.setdefault(object_id, {ID_COLUMN: object_id})
+            for key, value in object_metadata.items():
+                column_name = key
+                if column_name in vector_columns or column_name == ID_COLUMN:
+                    column_name = f"metadata_{column_name}"
+                row[column_name] = value
+
+        if not rows_by_id:
+            return 0
+
+        df = pd.DataFrame.from_records(list(rows_by_id.values()))
+        parquet_file = os.path.join(vectors_directory, f"{self.file_ctr}.parquet")
+        df.to_parquet(parquet_file)
+        if not hasattr(self, "parquet_schema"):
+            self.parquet_schema = pq.read_schema(parquet_file)
+        else:
+            self.parquet_schema = pa.unify_schemas(
+                [self.parquet_schema, pq.read_schema(parquet_file)]
+            )
+        self.file_structure.append(parquet_file)
+        self.file_ctr += 1
+        return len(df)

--- a/src/vdf_io/import_vdf/weaviate_import.py
+++ b/src/vdf_io/import_vdf/weaviate_import.py
@@ -1,0 +1,229 @@
+from typing import Dict, List
+
+from tqdm import tqdm
+
+from vdf_io.constants import DEFAULT_BATCH_SIZE, ID_COLUMN, INT_MAX
+from vdf_io.import_vdf.vdf_import_cls import ImportVDB
+from vdf_io.meta_types import NamespaceMeta
+from vdf_io.names import DBNames
+from vdf_io.util import (
+    clean_value,
+    cleanup_df,
+    divide_into_batches,
+    set_arg_from_input,
+    set_arg_from_password,
+)
+from vdf_io.weaviate_util import (
+    DEFAULT_WEAVIATE_GRPC_PORT,
+    DEFAULT_WEAVIATE_URL,
+    build_weaviate_vector_config,
+    connect_weaviate,
+    get_weaviate_collection,
+    get_weaviate_object_uuid,
+    is_local_weaviate_url,
+    list_weaviate_collection_names,
+    weaviate_collection_exists,
+)
+
+
+class ImportWeaviate(ImportVDB):
+    DB_NAME_SLUG = DBNames.WEAVIATE
+
+    @classmethod
+    def make_parser(cls, subparsers):
+        parser_weaviate = subparsers.add_parser(
+            cls.DB_NAME_SLUG, help="Import data to Weaviate"
+        )
+        parser_weaviate.add_argument(
+            "--url",
+            type=str,
+            help="URL of a local or cloud Weaviate instance",
+            default=DEFAULT_WEAVIATE_URL,
+        )
+        parser_weaviate.add_argument("--api_key", type=str, help="Weaviate API key")
+        parser_weaviate.add_argument(
+            "--grpc_port",
+            type=int,
+            help=f"Weaviate gRPC port (default: {DEFAULT_WEAVIATE_GRPC_PORT})",
+            default=DEFAULT_WEAVIATE_GRPC_PORT,
+        )
+        parser_weaviate.add_argument(
+            "--skip_init_checks",
+            type=bool,
+            help="Skip Weaviate client startup checks (default: True)",
+            default=True,
+        )
+
+    @classmethod
+    def import_vdb(cls, args):
+        set_arg_from_input(
+            args,
+            "url",
+            f"Enter the URL of the Weaviate instance (default: '{DEFAULT_WEAVIATE_URL}'): ",
+            str,
+            DEFAULT_WEAVIATE_URL,
+        )
+        set_arg_from_input(
+            args,
+            "grpc_port",
+            f"Enter the Weaviate gRPC port (default: {DEFAULT_WEAVIATE_GRPC_PORT}): ",
+            int,
+            DEFAULT_WEAVIATE_GRPC_PORT,
+        )
+        set_arg_from_input(
+            args,
+            "batch_size",
+            f"Enter the batch size for importing data (default: {DEFAULT_BATCH_SIZE}): ",
+            int,
+            DEFAULT_BATCH_SIZE,
+        )
+        if not is_local_weaviate_url(args["url"]):
+            set_arg_from_password(
+                args,
+                "api_key",
+                "Enter the Weaviate API key: ",
+                "WEAVIATE_API_KEY",
+            )
+        weaviate_import = cls(args)
+        weaviate_import.upsert_data()
+        return weaviate_import
+
+    def __init__(self, args):
+        super().__init__(args)
+        self.client = connect_weaviate(args)
+
+    def get_all_index_names(self):
+        return list_weaviate_collection_names(self.client)
+
+    def upsert_data(self):
+        self.total_imported_count = 0
+        indexes_content: Dict[str, List[NamespaceMeta]] = self.vdf_meta["indexes"]
+        if len(indexes_content) == 0:
+            raise ValueError("No indexes found in VDF_META.json")
+
+        existing_collections = self.get_all_index_names()
+        for index_name, index_meta in tqdm(
+            indexes_content.items(), desc="Importing indexes"
+        ):
+            for namespace_meta in tqdm(index_meta, desc="Importing namespaces"):
+                self.set_dims(namespace_meta, index_name)
+                new_collection_name = index_name + (
+                    f'_{namespace_meta["namespace"]}'
+                    if namespace_meta["namespace"]
+                    else ""
+                )
+                new_collection_name = self.create_new_name(
+                    new_collection_name, existing_collections
+                )
+                self.create_collection(new_collection_name, namespace_meta)
+                collection = get_weaviate_collection(self.client, new_collection_name)
+                existing_collections.append(new_collection_name)
+                self.import_namespace(collection, namespace_meta, new_collection_name)
+
+        tqdm.write("Data import completed successfully.")
+        self.args["imported_count"] = self.total_imported_count
+
+    def create_collection(self, collection_name, namespace_meta):
+        if weaviate_collection_exists(self.client, collection_name):
+            return
+
+        vector_columns, _ = self.get_vector_column_name(
+            collection_name, namespace_meta, multi_vector_supported=True
+        )
+        vector_config = build_weaviate_vector_config(
+            vector_columns, namespace_meta.get("metric")
+        )
+        if vector_config is not None:
+            try:
+                self.client.collections.create(
+                    name=collection_name,
+                    vector_config=vector_config,
+                )
+                return
+            except TypeError:
+                pass
+
+        self.client.collections.create(
+            name=collection_name,
+            vectorizer_config=None,
+        )
+
+    def import_namespace(self, collection, namespace_meta, collection_name):
+        data_path = namespace_meta["data_path"]
+        final_data_path = self.get_final_data_path(data_path)
+        parquet_files = self.get_parquet_files(final_data_path)
+        vector_column_names, _ = self.get_vector_column_name(
+            collection_name, namespace_meta, multi_vector_supported=True
+        )
+
+        batch_size = self.args.get("batch_size") or DEFAULT_BATCH_SIZE
+        max_rows = self.args.get("max_num_rows") or INT_MAX
+        for file in tqdm(parquet_files, desc="Iterating parquet files"):
+            file_path = self.get_file_path(final_data_path, file)
+            df = self.read_parquet_progress(
+                file_path,
+                max_num_rows=max_rows - self.total_imported_count,
+            )
+            df = cleanup_df(df)
+            for batch_df in tqdm(
+                divide_into_batches(df, batch_size),
+                desc="Importing batches",
+                total=max(1, len(df) // batch_size),
+            ):
+                self.upsert_batch(collection, batch_df, vector_column_names)
+                if self.total_imported_count >= max_rows:
+                    tqdm.write(f"Max rows to be imported {max_rows} hit. Exiting")
+                    return
+
+    def upsert_batch(self, collection, batch_df, vector_column_names):
+        with collection.batch.fixed_size(
+            batch_size=self.args.get("batch_size") or DEFAULT_BATCH_SIZE
+        ) as batch:
+            for _, row in batch_df.iterrows():
+                vector_payload = self.build_vector_payload(row, vector_column_names)
+                if not vector_payload:
+                    continue
+                properties = self.build_properties(row, vector_column_names)
+                object_uuid = get_weaviate_object_uuid(row[self.id_column])
+                if object_uuid != str(row[self.id_column]):
+                    properties.setdefault("vdf_original_id", str(row[self.id_column]))
+                batch.add_object(
+                    properties=properties,
+                    uuid=object_uuid,
+                    vector=vector_payload,
+                )
+                self.total_imported_count += 1
+                if batch.number_errors > 10:
+                    tqdm.write("Batch import stopped due to excessive errors.")
+                    break
+
+        failed_objects = collection.batch.failed_objects
+        if failed_objects:
+            tqdm.write(f"Number of failed imports: {len(failed_objects)}")
+            tqdm.write(f"First failed object: {failed_objects[0]}")
+
+    def build_vector_payload(self, row, vector_column_names):
+        vectors = {}
+        for vector_column_name in vector_column_names:
+            if vector_column_name not in row or row[vector_column_name] is None:
+                continue
+            vector = self.extract_vector(row[vector_column_name])
+            if vector is not None:
+                vectors[vector_column_name] = vector
+
+        if not vectors:
+            return None
+        if len(vectors) == 1 and "vector" in vectors:
+            return vectors["vector"]
+        return vectors
+
+    def build_properties(self, row, vector_column_names):
+        properties = {}
+        excluded_columns = set(vector_column_names) | {self.id_column, ID_COLUMN}
+        for key, value in row.to_dict().items():
+            if key in excluded_columns:
+                continue
+            value = clean_value(value)
+            if value is not None:
+                properties[key] = value
+        return properties

--- a/src/vdf_io/weaviate_util.py
+++ b/src/vdf_io/weaviate_util.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import inspect
+from urllib.parse import urlparse
+from uuid import NAMESPACE_URL, UUID, uuid5
+
+from vdf_io.names import DBNames
+from vdf_io.util import standardize_metric_reverse
+
+
+DEFAULT_WEAVIATE_URL = "http://localhost:8080"
+DEFAULT_WEAVIATE_GRPC_PORT = 50051
+
+
+def normalized_weaviate_url(url):
+    if not url:
+        url = DEFAULT_WEAVIATE_URL
+    if "://" not in url:
+        url = f"http://{url}"
+    return url
+
+
+def parsed_weaviate_url(url):
+    return urlparse(normalized_weaviate_url(url))
+
+
+def is_local_weaviate_url(url):
+    parsed = parsed_weaviate_url(url)
+    return parsed.hostname in {"localhost", "127.0.0.1", "::1"}
+
+
+def call_with_supported_kwargs(func, **kwargs):
+    try:
+        signature = inspect.signature(func)
+    except (TypeError, ValueError):
+        return func(**{key: value for key, value in kwargs.items() if value is not None})
+    supported_kwargs = {
+        key: value
+        for key, value in kwargs.items()
+        if key in signature.parameters and value is not None
+    }
+    return func(**supported_kwargs)
+
+
+def get_weaviate_auth(weaviate_module, api_key):
+    if not api_key:
+        return None
+    return weaviate_module.auth.AuthApiKey(api_key)
+
+
+def connect_weaviate(args):
+    import weaviate
+
+    url = normalized_weaviate_url(args.get("url"))
+    api_key = args.get("api_key")
+    grpc_port = int(args.get("grpc_port") or DEFAULT_WEAVIATE_GRPC_PORT)
+    skip_init_checks = args.get("skip_init_checks", True)
+    parsed = parsed_weaviate_url(url)
+    host = parsed.hostname or "localhost"
+    http_port = parsed.port or (443 if parsed.scheme == "https" else 8080)
+    auth_credentials = get_weaviate_auth(weaviate, api_key)
+
+    if (
+        is_local_weaviate_url(url)
+        and not api_key
+        and hasattr(weaviate, "connect_to_local")
+    ):
+        return call_with_supported_kwargs(
+            weaviate.connect_to_local,
+            host=host,
+            port=http_port,
+            grpc_port=grpc_port,
+            skip_init_checks=skip_init_checks,
+        )
+
+    if api_key and hasattr(weaviate, "connect_to_weaviate_cloud"):
+        return call_with_supported_kwargs(
+            weaviate.connect_to_weaviate_cloud,
+            cluster_url=url,
+            auth_credentials=auth_credentials,
+            skip_init_checks=skip_init_checks,
+        )
+
+    if api_key and hasattr(weaviate, "connect_to_wcs"):
+        return call_with_supported_kwargs(
+            weaviate.connect_to_wcs,
+            cluster_url=url,
+            auth_credentials=auth_credentials,
+            skip_init_checks=skip_init_checks,
+        )
+
+    if hasattr(weaviate, "connect_to_custom"):
+        return call_with_supported_kwargs(
+            weaviate.connect_to_custom,
+            http_host=host,
+            http_port=http_port,
+            http_secure=parsed.scheme == "https",
+            grpc_host=args.get("grpc_host") or host,
+            grpc_port=grpc_port,
+            grpc_secure=args.get("grpc_secure", parsed.scheme == "https"),
+            auth_credentials=auth_credentials,
+            skip_init_checks=skip_init_checks,
+        )
+
+    return call_with_supported_kwargs(
+        weaviate.connect_to_local,
+        host=host,
+        port=http_port,
+        grpc_port=grpc_port,
+        skip_init_checks=skip_init_checks,
+    )
+
+
+def list_weaviate_collection_names(client):
+    collections = client.collections.list_all()
+    if isinstance(collections, dict):
+        return list(collections.keys())
+    names = []
+    for collection in collections:
+        names.append(getattr(collection, "name", collection))
+    return names
+
+
+def get_weaviate_collection(client, collection_name):
+    collections = client.collections
+    if hasattr(collections, "use"):
+        return collections.use(collection_name)
+    if hasattr(collections, "get"):
+        try:
+            return collections.get(collection_name)
+        except TypeError:
+            return collections.get(name=collection_name)
+    raise AttributeError("Weaviate client collections object has no use/get method")
+
+
+def weaviate_collection_exists(client, collection_name):
+    if hasattr(client.collections, "exists"):
+        return client.collections.exists(collection_name)
+    return collection_name in list_weaviate_collection_names(client)
+
+
+def standard_metric_to_weaviate(metric):
+    if metric is None:
+        return "cosine"
+    metric_text = str(metric).lower()
+    if "cos" in metric_text:
+        return "cosine"
+    if "euclid" in metric_text or "l2" in metric_text:
+        return "l2-squared"
+    if "dot" in metric_text:
+        return "dot"
+    if "manhattan" in metric_text:
+        return "manhattan"
+    return standardize_metric_reverse(metric, DBNames.WEAVIATE)
+
+
+def get_weaviate_distance_config(metric):
+    try:
+        import weaviate.classes.config as wvcc
+    except ImportError:
+        return None
+
+    if not hasattr(wvcc, "VectorDistances"):
+        return None
+
+    weaviate_metric = standard_metric_to_weaviate(metric)
+    distance_map = {
+        "cosine": "COSINE",
+        "l2-squared": "L2_SQUARED",
+        "dot": "DOT",
+        "manhattan": "MANHATTAN",
+    }
+    distance_name = distance_map.get(weaviate_metric)
+    if not distance_name or not hasattr(wvcc.VectorDistances, distance_name):
+        return None
+    return getattr(wvcc.VectorDistances, distance_name)
+
+
+def build_weaviate_vector_config(vector_columns, metric=None):
+    try:
+        import weaviate.classes.config as wvcc
+    except ImportError:
+        return None
+
+    if not hasattr(wvcc, "Configure") or not hasattr(wvcc.Configure, "Vectors"):
+        return None
+
+    distance = get_weaviate_distance_config(metric)
+    vector_index_config = None
+    if distance is not None and hasattr(wvcc.Configure, "VectorIndex"):
+        vector_index_config = wvcc.Configure.VectorIndex.hnsw(
+            distance_metric=distance
+        )
+
+    def self_provided_config(vector_name=None):
+        kwargs = {}
+        if vector_name is not None:
+            kwargs["name"] = vector_name
+        if vector_index_config is not None:
+            kwargs["vector_index_config"] = vector_index_config
+        return wvcc.Configure.Vectors.self_provided(**kwargs)
+
+    if len(vector_columns) == 1 and vector_columns[0] == "vector":
+        return self_provided_config()
+    return [self_provided_config(vector_column) for vector_column in vector_columns]
+
+
+def serializable_weaviate_config(config):
+    if hasattr(config, "model_dump"):
+        config = config.model_dump()
+    elif hasattr(config, "dict"):
+        config = config.dict()
+    elif hasattr(config, "__dict__"):
+        config = vars(config)
+
+    if isinstance(config, dict):
+        return {
+            str(key): serializable_weaviate_config(value)
+            for key, value in config.items()
+            if not str(key).startswith("_")
+        }
+    if isinstance(config, (list, tuple, set)):
+        return [serializable_weaviate_config(value) for value in config]
+    if isinstance(config, (str, int, float, bool)) or config is None:
+        return config
+    return str(config)
+
+
+def get_weaviate_object_uuid(raw_id):
+    try:
+        return str(UUID(str(raw_id)))
+    except ValueError:
+        return str(uuid5(NAMESPACE_URL, str(raw_id)))

--- a/src/vdf_io/weaviate_util.py
+++ b/src/vdf_io/weaviate_util.py
@@ -33,7 +33,9 @@ def call_with_supported_kwargs(func, **kwargs):
     try:
         signature = inspect.signature(func)
     except (TypeError, ValueError):
-        return func(**{key: value for key, value in kwargs.items() if value is not None})
+        return func(
+            **{key: value for key, value in kwargs.items() if value is not None}
+        )
     supported_kwargs = {
         key: value
         for key, value in kwargs.items()
@@ -188,9 +190,7 @@ def build_weaviate_vector_config(vector_columns, metric=None):
     distance = get_weaviate_distance_config(metric)
     vector_index_config = None
     if distance is not None and hasattr(wvcc.Configure, "VectorIndex"):
-        vector_index_config = wvcc.Configure.VectorIndex.hnsw(
-            distance_metric=distance
-        )
+        vector_index_config = wvcc.Configure.VectorIndex.hnsw(distance_metric=distance)
 
     def self_provided_config(vector_name=None):
         kwargs = {}

--- a/tests/test_weaviate_support_static.py
+++ b/tests/test_weaviate_support_static.py
@@ -1,0 +1,58 @@
+import ast
+from pathlib import Path
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def class_methods(path, class_name):
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            return {
+                item.name
+                for item in node.body
+                if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef))
+            }
+    raise AssertionError(f"{class_name} not found in {path}")
+
+
+class WeaviateSupportStaticTests(unittest.TestCase):
+    def test_export_weaviate_implements_export_contract(self):
+        methods = class_methods(
+            REPO_ROOT / "src" / "vdf_io" / "export_vdf" / "weaviate_export.py",
+            "ExportWeaviate",
+        )
+
+        self.assertTrue(
+            {
+                "make_parser",
+                "export_vdb",
+                "get_all_index_names",
+                "get_index_names",
+                "get_data",
+            }.issubset(methods)
+        )
+
+    def test_import_weaviate_implements_import_contract(self):
+        import_path = (
+            REPO_ROOT / "src" / "vdf_io" / "import_vdf" / "weaviate_import.py"
+        )
+        self.assertTrue(import_path.exists())
+
+        methods = class_methods(import_path, "ImportWeaviate")
+        self.assertTrue(
+            {
+                "make_parser",
+                "import_vdb",
+                "get_all_index_names",
+                "upsert_data",
+                "create_collection",
+                "build_vector_payload",
+            }.issubset(methods)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_weaviate_support_static.py
+++ b/tests/test_weaviate_support_static.py
@@ -36,9 +36,7 @@ class WeaviateSupportStaticTests(unittest.TestCase):
         )
 
     def test_import_weaviate_implements_import_contract(self):
-        import_path = (
-            REPO_ROOT / "src" / "vdf_io" / "import_vdf" / "weaviate_import.py"
-        )
+        import_path = REPO_ROOT / "src" / "vdf_io" / "import_vdf" / "weaviate_import.py"
         self.assertTrue(import_path.exists())
 
         methods = class_methods(import_path, "ImportWeaviate")


### PR DESCRIPTION
## Summary
- Adds a shared Weaviate connection/helper module for local and cloud instances.
- Completes Weaviate export with collection discovery, selected collection export, vector retrieval, VDF metadata generation, and named-vector columns.
- Adds Weaviate import with automatic collection creation, self-provided vector config, deterministic UUID handling for non-UUID VDF ids, and named-vector batch import.
- Updates the support matrix to mark Weaviate import/export as supported.
- Adds CLI help docs for the new Weaviate import/export commands.

Refs #74

## Verification
- `python -m unittest discover -s tests`
- `python -m py_compile src\vdf_io\weaviate_util.py src\vdf_io\export_vdf\weaviate_export.py src\vdf_io\import_vdf\weaviate_import.py`
- `git diff --check`

## Notes
The local environment did not have the full project dependency set installed, so the verification includes static contract coverage plus Python syntax compilation for the new modules.