### PR TITLE
Add Weaviate VDF import/export support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ See the [Contributing](#contributing) section to add support for your favorite v
 | DataStax Astra DB              | ✅     | ✅     |
 | Chroma                         | ✅     | ✅     |
 | Turbopuffer                    | ✅     | ✅     |
+| Weaviate                       | ✅     | ✅     |
 
 </details>
 
@@ -67,7 +68,6 @@ See the [Contributing](#contributing) section to add support for your favorite v
 | Vector Database                | Import | Export |
 |--------------------------------|--------|--------|
 | Azure AI Search                | ❌     | ❌     |
-| Weaviate                       | ❌     | ❌     |
 | MongoDB Atlas                  | ❌     | ❌     |
 | OpenSearch                     | ❌     | ❌     |
 | Apache Cassandra               | ❌     | ❌     |

--- a/src/vdf_io/export_vdf/weaviate_export.py
+++ b/src/vdf_io/export_vdf/weaviate_export.py
@@ -1,15 +1,21 @@
+import json
 import os
 
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
 from tqdm import tqdm
-import weaviate
 
+from vdf_io.constants import DEFAULT_BATCH_SIZE, DISK_SPACE_LIMIT, ID_COLUMN
 from vdf_io.export_vdf.vdb_export_cls import ExportVDB
 from vdf_io.names import DBNames
 from vdf_io.util import set_arg_from_input, set_arg_from_password
-
-# Set these environment variables
-URL = os.getenv("YOUR_WCS_URL")
-APIKEY = os.getenv("YOUR_WCS_API_KEY")
+from vdf_io.weaviate_util import (
+    collection_names,
+    connect_weaviate,
+    extract_distance,
+    object_to_plain_dict,
+)
 
 
 class ExportWeaviate(ExportVDB):
@@ -24,7 +30,19 @@ class ExportWeaviate(ExportVDB):
         parser_weaviate.add_argument("--url", type=str, help="URL of Weaviate instance")
         parser_weaviate.add_argument("--api_key", type=str, help="Weaviate API key")
         parser_weaviate.add_argument(
+            "--grpc_host", type=str, help="Weaviate gRPC host for custom deployments"
+        )
+        parser_weaviate.add_argument(
+            "--grpc_port", type=int, help="Weaviate gRPC port", default=50051
+        )
+        parser_weaviate.add_argument(
             "--classes", type=str, help="Classes to export (comma-separated)"
+        )
+        parser_weaviate.add_argument(
+            "--batch_size",
+            type=int,
+            help="Batch size for exporting data",
+            default=DEFAULT_BATCH_SIZE,
         )
 
     @classmethod
@@ -32,19 +50,25 @@ class ExportWeaviate(ExportVDB):
         set_arg_from_input(
             args,
             "url",
-            "Enter the URL of Weaviate instance: ",
+            "Enter the URL of Weaviate instance (default: http://localhost:8080): ",
             str,
+            "http://localhost:8080",
         )
         set_arg_from_password(
             args,
             "api_key",
-            "Enter the Weaviate API key: ",
+            "Enter the Weaviate API key (leave blank for local unauthenticated instances): ",
             "WEAVIATE_API_KEY",
         )
-        weaviate_export = ExportWeaviate(args)
-        weaviate_export.all_classes = list(
-            weaviate_export.client.collections.list_all().keys()
+        set_arg_from_input(
+            args,
+            "batch_size",
+            f"Enter the batch size for exporting data (default: {DEFAULT_BATCH_SIZE}): ",
+            int,
+            DEFAULT_BATCH_SIZE,
         )
+        weaviate_export = ExportWeaviate(args)
+        weaviate_export.all_classes = weaviate_export.get_all_index_names()
         set_arg_from_input(
             weaviate_export.args,
             "classes",
@@ -58,13 +82,13 @@ class ExportWeaviate(ExportVDB):
     # Connect to a WCS instance
     def __init__(self, args):
         super().__init__(args)
-        self.client = weaviate.connect_to_wcs(
-            cluster_url=self.args["url"],
-            auth_credentials=weaviate.auth.AuthApiKey(self.args["api_key"]),
-            skip_init_checks=True,
-        )
+        self.client = connect_weaviate(self.args)
+
+    def get_all_index_names(self):
+        return collection_names(self.client)
 
     def get_index_names(self):
+        self.all_classes = getattr(self, "all_classes", self.get_all_index_names())
         if self.args.get("classes") is None:
             return self.all_classes
         else:
@@ -76,14 +100,100 @@ class ExportWeaviate(ExportVDB):
             return [c for c in self.all_classes if c in input_classes]
 
     def get_data(self):
-        # Get all objects of a class
+        batch_size = self.args.get("batch_size") or DEFAULT_BATCH_SIZE
         index_names = self.get_index_names()
-        for class_name in index_names:
+        index_metas = {}
+        for class_name in tqdm(index_names, desc="Exporting Weaviate collections"):
             collection = self.client.collections.get(class_name)
-            response = collection.aggregate.over_all(total_count=True)
-            print(f"{response.total_count=}")
+            vectors_directory = self.create_vec_dir(class_name)
+            index_config = object_to_plain_dict(collection.config.get())
+            distance = extract_distance(index_config)
+            total = self._collection_count(collection)
+            rows = []
+            exported = 0
+            dim = -1
+            vector_columns = set()
 
-            # objects = self.client.query.get(
-            #     wvq.Objects(wvq.Class(class_name)).with_limit(1000)
-            # )
-            # print(objects)
+            for item in tqdm(
+                collection.iterator(include_vector=True),
+                desc=f"Exporting {class_name}",
+                total=total if total >= 0 else None,
+            ):
+                vectors = self._extract_vectors(getattr(item, "vector", None))
+                if not vectors:
+                    continue
+                vector_columns.update(vectors.keys())
+                if dim == -1:
+                    dim = len(next(iter(vectors.values())))
+
+                row = {
+                    ID_COLUMN: str(getattr(item, "uuid", "")),
+                    **(getattr(item, "properties", {}) or {}),
+                    **vectors,
+                }
+                rows.append(row)
+                if len(rows) >= batch_size or sys_getsizeof(rows) > DISK_SPACE_LIMIT:
+                    exported += self._save_rows_to_parquet(rows, vectors_directory)
+                    rows = []
+
+            if rows:
+                exported += self._save_rows_to_parquet(rows, vectors_directory)
+            self.args["exported_count"] += exported
+            index_metas[class_name] = [
+                self.get_namespace_meta(
+                    class_name,
+                    vectors_directory,
+                    total=total,
+                    num_vectors_exported=exported,
+                    dim=dim,
+                    index_config=index_config,
+                    vector_columns=sorted(vector_columns) or ["vector"],
+                    distance=distance,
+                )
+            ]
+
+        self.file_structure.append(os.path.join(self.vdf_directory, "VDF_META.json"))
+        internal_metadata = self.get_basic_vdf_meta(index_metas)
+        meta_text = json.dumps(internal_metadata.model_dump(), indent=4, default=str)
+        tqdm.write(meta_text)
+        with open(os.path.join(self.vdf_directory, "VDF_META.json"), "w") as json_file:
+            json_file.write(meta_text)
+        return True
+
+    def _collection_count(self, collection):
+        try:
+            return len(collection)
+        except Exception:
+            response = collection.aggregate.over_all(total_count=True)
+            return response.total_count
+
+    def _extract_vectors(self, vector_payload):
+        if vector_payload is None:
+            return {}
+        if isinstance(vector_payload, dict):
+            return {
+                key: list(value)
+                for key, value in vector_payload.items()
+                if value is not None
+            }
+        return {"vector": list(vector_payload)}
+
+    def _save_rows_to_parquet(self, rows, vectors_directory):
+        parquet_file = os.path.join(vectors_directory, f"{self.file_ctr}.parquet")
+        df = pd.DataFrame.from_records(rows)
+        df.to_parquet(parquet_file)
+        if not hasattr(self, "parquet_schema"):
+            self.parquet_schema = pq.read_schema(parquet_file)
+        else:
+            self.parquet_schema = pa.unify_schemas(
+                [self.parquet_schema, pq.read_schema(parquet_file)]
+            )
+        self.file_structure.append(parquet_file)
+        self.file_ctr += 1
+        return len(df)
+
+
+def sys_getsizeof(value):
+    import sys
+
+    return sys.getsizeof(value)

--- a/src/vdf_io/import_vdf/weaviate_import.py
+++ b/src/vdf_io/import_vdf/weaviate_import.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+import json
+from typing import Dict, List
+from uuid import NAMESPACE_URL, UUID, uuid5
+
+import numpy as np
+import pandas as pd
+from dotenv import load_dotenv
+from tqdm import tqdm
+
+from vdf_io.constants import DEFAULT_BATCH_SIZE, INT_MAX
+from vdf_io.import_vdf.vdf_import_cls import ImportVDB
+from vdf_io.meta_types import NamespaceMeta
+from vdf_io.names import DBNames
+from vdf_io.util import (
+    cleanup_df,
+    divide_into_batches,
+    set_arg_from_input,
+    set_arg_from_password,
+)
+from vdf_io.weaviate_util import (
+    build_vector_config,
+    clean_property_value,
+    collection_names,
+    connect_weaviate,
+)
+
+
+load_dotenv()
+
+
+class ImportWeaviate(ImportVDB):
+    DB_NAME_SLUG = DBNames.WEAVIATE
+
+    @classmethod
+    def make_parser(cls, subparsers):
+        parser_weaviate = subparsers.add_parser(
+            cls.DB_NAME_SLUG, help="Import VDF data to Weaviate"
+        )
+        parser_weaviate.add_argument(
+            "--url",
+            type=str,
+            help="Weaviate URL (default: http://localhost:8080)",
+            default="http://localhost:8080",
+        )
+        parser_weaviate.add_argument("--api_key", type=str, help="Weaviate API key")
+        parser_weaviate.add_argument(
+            "--grpc_host", type=str, help="Weaviate gRPC host for custom deployments"
+        )
+        parser_weaviate.add_argument(
+            "--grpc_port", type=int, help="Weaviate gRPC port", default=50051
+        )
+
+    @classmethod
+    def import_vdb(cls, args):
+        set_arg_from_input(
+            args,
+            "url",
+            "Enter the URL of Weaviate instance (default: http://localhost:8080): ",
+            str,
+            "http://localhost:8080",
+        )
+        set_arg_from_password(
+            args,
+            "api_key",
+            "Enter the Weaviate API key (leave blank for local unauthenticated instances): ",
+            "WEAVIATE_API_KEY",
+        )
+        weaviate_import = ImportWeaviate(args)
+        weaviate_import.upsert_data()
+        return weaviate_import
+
+    def __init__(self, args):
+        super().__init__(args)
+        self.client = connect_weaviate(self.args)
+
+    def get_all_index_names(self):
+        return collection_names(self.client)
+
+    def upsert_data(self):
+        self.total_imported_count = 0
+        indexes_content: Dict[str, List[NamespaceMeta]] = self.vdf_meta["indexes"]
+        index_names: List[str] = list(indexes_content.keys())
+        if len(index_names) == 0:
+            raise ValueError("No indexes found in VDF_META.json")
+
+        collections = self.get_all_index_names()
+        max_num_rows = self.args.get("max_num_rows") or INT_MAX
+        for index_name, index_meta in tqdm(
+            indexes_content.items(), desc="Importing indexes"
+        ):
+            for namespace_meta in tqdm(index_meta, desc="Importing namespaces"):
+                self.set_dims(namespace_meta, index_name)
+                data_path = namespace_meta["data_path"]
+                final_data_path = self.get_final_data_path(data_path)
+                parquet_files = self.get_parquet_files(final_data_path)
+
+                new_collection_name = index_name + (
+                    f'_{namespace_meta["namespace"]}'
+                    if namespace_meta["namespace"]
+                    else ""
+                )
+                new_collection_name = self.create_new_name(
+                    new_collection_name, collections
+                )
+                vector_column_names, _ = self.get_vector_column_name(
+                    index_name, namespace_meta, multi_vector_supported=True
+                )
+
+                collection = None
+                property_types = {}
+                for file in tqdm(parquet_files, desc="Iterating parquet files"):
+                    remaining = max_num_rows - self.total_imported_count
+                    if remaining <= 0:
+                        break
+                    file_path = self.get_file_path(final_data_path, file)
+                    df = self.read_parquet_progress(
+                        file_path,
+                        max_num_rows=remaining,
+                    )
+                    df = cleanup_df(df)
+
+                    if collection is None:
+                        collection, property_types = self._get_or_create_collection(
+                            new_collection_name,
+                            collections,
+                            namespace_meta,
+                            vector_column_names,
+                            df,
+                        )
+                        if new_collection_name not in collections:
+                            collections.append(new_collection_name)
+
+                    batch_size = self.args.get("batch_size") or DEFAULT_BATCH_SIZE
+                    for batch_df in tqdm(
+                        divide_into_batches(df, batch_size),
+                        desc="Importing batches",
+                        total=max(len(df) // batch_size, 1),
+                    ):
+                        self._insert_batch(
+                            collection,
+                            new_collection_name,
+                            batch_df,
+                            vector_column_names,
+                            property_types,
+                            batch_size,
+                        )
+                        if self.total_imported_count >= max_num_rows:
+                            break
+
+                if collection is not None:
+                    tqdm.write(
+                        f"Imported {self.total_imported_count} rows into {new_collection_name}"
+                    )
+        print("Data imported successfully")
+
+    def _get_or_create_collection(
+        self,
+        collection_name,
+        collections,
+        namespace_meta,
+        vector_column_names,
+        df,
+    ):
+        property_types = self._property_types(df, vector_column_names)
+        if collection_name not in collections:
+            kwargs = build_vector_config(
+                vector_column_names,
+                namespace_meta.get("metric"),
+            )
+            properties = self._properties(property_types)
+            try:
+                self.client.collections.create(
+                    name=collection_name,
+                    properties=properties,
+                    **kwargs,
+                )
+            except TypeError:
+                self.client.collections.create(
+                    collection_name,
+                    properties=properties,
+                    **kwargs,
+                )
+        return self.client.collections.get(collection_name), property_types
+
+    def _insert_batch(
+        self,
+        collection,
+        collection_name,
+        batch_df,
+        vector_column_names,
+        property_types,
+        batch_size,
+    ):
+        inserted = 0
+        skipped = 0
+        with collection.batch.fixed_size(batch_size=batch_size) as batch:
+            for _, row in batch_df.iterrows():
+                vectors = {
+                    vector_column_name: self.extract_vector(row[vector_column_name])
+                    for vector_column_name in vector_column_names
+                    if vector_column_name in row
+                    and not self._is_empty(row[vector_column_name])
+                }
+                vectors = {k: v for k, v in vectors.items() if v}
+                if not vectors:
+                    skipped += 1
+                    continue
+
+                row_id = row.get(self.id_column)
+                properties = self._row_properties(
+                    row,
+                    vector_column_names,
+                    property_types,
+                    row_id,
+                )
+                vector = (
+                    next(iter(vectors.values()))
+                    if len(vector_column_names) == 1
+                    else vectors
+                )
+                batch.add_object(
+                    properties=properties,
+                    uuid=self._object_uuid(collection_name, row_id),
+                    vector=vector,
+                )
+                inserted += 1
+
+        failed_objects = getattr(collection.batch, "failed_objects", None)
+        if failed_objects:
+            tqdm.write(f"Warning: {len(failed_objects)} Weaviate objects failed import")
+            tqdm.write(f"First failed object: {failed_objects[0]}")
+        if skipped:
+            tqdm.write(f"Skipped {skipped} rows with no usable vector")
+        self.total_imported_count += inserted
+
+    def _property_types(self, df, vector_column_names):
+        property_types = {}
+        for column in df.columns:
+            if column in vector_column_names or column == self.id_column:
+                continue
+            property_types[column] = self._data_type_for_column(df[column])
+        property_types["vdf_original_id"] = self._data_type("text")
+        return property_types
+
+    def _properties(self, property_types):
+        from weaviate.classes.config import Property
+
+        return [
+            Property(name=column, data_type=data_type)
+            for column, data_type in property_types.items()
+        ]
+
+    def _row_properties(self, row, vector_column_names, property_types, row_id):
+        properties = {}
+        for column, data_type in property_types.items():
+            if column == "vdf_original_id":
+                continue
+            if column in vector_column_names or column == self.id_column:
+                continue
+            value = clean_property_value(row.get(column))
+            if value is not None:
+                properties[column] = self._coerce_property(value, data_type)
+        properties["vdf_original_id"] = str(row_id)
+        return properties
+
+    def _data_type_for_column(self, series):
+        series = series.dropna()
+        if len(series) == 0:
+            return self._data_type("text")
+        sample = clean_property_value(series.iloc[0])
+        if isinstance(sample, bool):
+            return self._data_type("bool")
+        if isinstance(sample, int) and not isinstance(sample, bool):
+            return self._data_type("int")
+        if isinstance(sample, float):
+            return self._data_type("number")
+        if isinstance(sample, list) and sample:
+            item = sample[0]
+            if isinstance(item, bool):
+                return self._data_type("bool_array")
+            if isinstance(item, int) and not isinstance(item, bool):
+                return self._data_type("int_array")
+            if isinstance(item, float):
+                return self._data_type("number_array")
+            if isinstance(item, str):
+                return self._data_type("text_array")
+        return self._data_type("text")
+
+    def _data_type(self, name):
+        from weaviate.classes.config import DataType
+
+        return {
+            "text": DataType.TEXT,
+            "int": DataType.INT,
+            "number": DataType.NUMBER,
+            "bool": DataType.BOOL,
+            "text_array": DataType.TEXT_ARRAY,
+            "int_array": DataType.INT_ARRAY,
+            "number_array": DataType.NUMBER_ARRAY,
+            "bool_array": DataType.BOOL_ARRAY,
+        }[name]
+
+    def _coerce_property(self, value, data_type):
+        type_name = getattr(data_type, "value", str(data_type)).lower()
+        if "array" in type_name and isinstance(value, list):
+            return value
+        if "text" in type_name and not isinstance(value, str):
+            return json.dumps(value, default=str)
+        return value
+
+    def _object_uuid(self, collection_name, row_id):
+        try:
+            return str(UUID(str(row_id)))
+        except (TypeError, ValueError):
+            return str(uuid5(NAMESPACE_URL, f"vdf_io:{collection_name}:{row_id}"))
+
+    def _is_empty(self, value):
+        if value is None:
+            return True
+        if isinstance(value, (list, tuple, np.ndarray)):
+            return len(value) == 0
+        return bool(pd.isna(value))

--- a/src/vdf_io/weaviate_util.py
+++ b/src/vdf_io/weaviate_util.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from enum import Enum
+from urllib.parse import urlparse
+
+import numpy as np
+import pandas as pd
+import weaviate
+
+from qdrant_client.http.models import Distance
+
+from vdf_io.names import DBNames
+from vdf_io.util import standardize_metric_reverse
+
+
+def connect_weaviate(args):
+    url = args.get("url") or "http://localhost:8080"
+    api_key = args.get("api_key")
+    grpc_host = args.get("grpc_host")
+    grpc_port = args.get("grpc_port")
+    auth_credentials = _api_key_auth(api_key) if api_key else None
+
+    parsed = urlparse(url if "://" in url else f"http://{url}")
+    host = parsed.hostname or "localhost"
+    secure = parsed.scheme == "https"
+    http_port = parsed.port or (443 if secure else 8080)
+
+    if _is_local_host(host) and not api_key:
+        return _call_connect(
+            weaviate.connect_to_local,
+            host=host,
+            port=http_port,
+            grpc_port=grpc_port or 50051,
+        )
+
+    if hasattr(weaviate, "connect_to_custom"):
+        kwargs = {
+            "http_host": host,
+            "http_port": http_port,
+            "http_secure": secure,
+            "grpc_host": grpc_host or host,
+            "grpc_port": grpc_port or (443 if secure else 50051),
+            "grpc_secure": secure,
+        }
+        if auth_credentials is not None:
+            kwargs["auth_credentials"] = auth_credentials
+        return _call_connect(weaviate.connect_to_custom, **kwargs)
+
+    return _call_connect(
+        weaviate.connect_to_wcs,
+        cluster_url=url,
+        auth_credentials=auth_credentials,
+    )
+
+
+def collection_names(client):
+    return list(client.collections.list_all().keys())
+
+
+def object_to_plain_dict(value):
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, dict):
+        return {k: object_to_plain_dict(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [object_to_plain_dict(v) for v in value]
+    for method_name in ("to_dict", "model_dump", "dict"):
+        method = getattr(value, method_name, None)
+        if callable(method):
+            try:
+                return object_to_plain_dict(method())
+            except TypeError:
+                continue
+    if hasattr(value, "__dict__"):
+        return object_to_plain_dict(
+            {k: v for k, v in value.__dict__.items() if not k.startswith("_")}
+        )
+    return str(value)
+
+
+def extract_distance(index_config):
+    config = object_to_plain_dict(index_config)
+    if not isinstance(config, dict):
+        return None
+    return _find_key(config, "distance_metric") or _find_key(config, "distance")
+
+
+def to_weaviate_distance(metric):
+    distance = standardize_metric_reverse(metric or Distance.COSINE, DBNames.WEAVIATE)
+    try:
+        from weaviate.classes.config import VectorDistances
+
+        return {
+            "cosine": VectorDistances.COSINE,
+            "dot": VectorDistances.DOT,
+            "l2-squared": VectorDistances.L2_SQUARED,
+            "manhattan": VectorDistances.MANHATTAN,
+        }.get(distance, VectorDistances.COSINE)
+    except Exception:
+        return distance
+
+
+def build_vector_config(vector_column_names, distance):
+    from weaviate.classes.config import Configure
+
+    vector_distance = to_weaviate_distance(distance)
+
+    if hasattr(Configure, "Vectors"):
+        vector_index_config = Configure.VectorIndex.hnsw(distance_metric=vector_distance)
+        if len(vector_column_names) == 1:
+            try:
+                return {
+                    "vector_config": Configure.Vectors.self_provided(
+                        vector_index_config=vector_index_config
+                    )
+                }
+            except TypeError:
+                return {
+                    "vector_config": Configure.Vectors.self_provided(
+                        name=vector_column_names[0],
+                        vector_index_config=vector_index_config,
+                    )
+                }
+        return {
+            "vector_config": [
+                Configure.Vectors.self_provided(
+                    name=vector_column_name,
+                    vector_index_config=vector_index_config,
+                )
+                for vector_column_name in vector_column_names
+            ]
+        }
+
+    return {"vectorizer_config": Configure.Vectorizer.none()}
+
+
+def clean_property_value(value):
+    if value is None:
+        return None
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, (list, tuple)):
+        cleaned = [clean_property_value(v) for v in value]
+        return [v for v in cleaned if v is not None]
+    if isinstance(value, dict):
+        return {k: clean_property_value(v) for k, v in value.items()}
+    if pd.isna(value):
+        return None
+    return str(value)
+
+
+def _api_key_auth(api_key):
+    if hasattr(weaviate, "auth") and hasattr(weaviate.auth, "AuthApiKey"):
+        return weaviate.auth.AuthApiKey(api_key)
+
+    from weaviate.classes.init import Auth
+
+    return Auth.api_key(api_key)
+
+
+def _call_connect(connect_fn, **kwargs):
+    try:
+        return connect_fn(**kwargs, skip_init_checks=True)
+    except TypeError:
+        return connect_fn(**kwargs)
+
+
+def _is_local_host(host):
+    return host in {"localhost", "127.0.0.1", "::1", "0.0.0.0"}
+
+
+def _find_key(value, target_key):
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if key == target_key:
+                return item.value if isinstance(item, Enum) else item
+            found = _find_key(item, target_key)
+            if found is not None:
+                return found
+    elif isinstance(value, list):
+        for item in value:
+            found = _find_key(item, target_key)
+            if found is not None:
+                return found
+    return None

--- a/src/vdf_io/weaviate_util.py
+++ b/src/vdf_io/weaviate_util.py
@@ -108,7 +108,9 @@ def build_vector_config(vector_column_names, distance):
     vector_distance = to_weaviate_distance(distance)
 
     if hasattr(Configure, "Vectors"):
-        vector_index_config = Configure.VectorIndex.hnsw(distance_metric=vector_distance)
+        vector_index_config = Configure.VectorIndex.hnsw(
+            distance_metric=vector_distance
+        )
         if len(vector_column_names) == 1:
             try:
                 return {


### PR DESCRIPTION
Implements Weaviate support for #74.\n\nChanges:\n- Add shared Weaviate connection/config helpers\n- Complete Weaviate export to VDF parquet and VDF_META.json\n- Add Weaviate import from VDF with batch inserts\n- Support local/custom deployments, API-key auth, and gRPC host/port options\n- Preserve original VDF ids and generate deterministic Weaviate UUIDs where needed\n- Support multiple/named vector columns\n- Update README support table\n\nValidation:\n- PYTHONPYCACHEPREFIX=/private/tmp/vector-io-pycache python3 -m py_compile src/vdf_io/weaviate_util.py src/vdf_io/export_vdf/weaviate_export.py src/vdf_io/import_vdf/weaviate_import.py\n- git diff --check\n\nNote:\nI did not run a live Weaviate integration test because no test instance/API key was available.