### PR TITLE
Add Weaviate import/export support

### DIFF
--- a/src/vdf_io/export_vdf/weaviate_export.py
+++ b/src/vdf_io/export_vdf/weaviate_export.py
@@ -127,10 +127,7 @@ class ExportWeaviate(ExportVDB):
         collections = self.client.collections.list_all()
         if isinstance(collections, dict):
             return list(collections.keys())
-        return [
-            getattr(collection, "name", collection)
-            for collection in collections
-        ]
+        return [getattr(collection, "name", collection) for collection in collections]
 
     def get_index_names(self):
         requested = self.args.get("collections") or self.args.get("classes")

--- a/src/vdf_io/export_vdf/weaviate_export.py
+++ b/src/vdf_io/export_vdf/weaviate_export.py
@@ -1,15 +1,17 @@
+import json
 import os
+from typing import Any, Dict, Iterable, List, Tuple
 
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
 from tqdm import tqdm
 import weaviate
 
+from vdf_io.constants import DEFAULT_BATCH_SIZE, ID_COLUMN
 from vdf_io.export_vdf.vdb_export_cls import ExportVDB
 from vdf_io.names import DBNames
 from vdf_io.util import set_arg_from_input, set_arg_from_password
-
-# Set these environment variables
-URL = os.getenv("YOUR_WCS_URL")
-APIKEY = os.getenv("YOUR_WCS_API_KEY")
 
 
 class ExportWeaviate(ExportVDB):
@@ -21,10 +23,32 @@ class ExportWeaviate(ExportVDB):
             cls.DB_NAME_SLUG, help="Export data from Weaviate"
         )
 
-        parser_weaviate.add_argument("--url", type=str, help="URL of Weaviate instance")
+        parser_weaviate.add_argument("--url", type=str, help="URL of Weaviate Cloud")
         parser_weaviate.add_argument("--api_key", type=str, help="Weaviate API key")
         parser_weaviate.add_argument(
-            "--classes", type=str, help="Classes to export (comma-separated)"
+            "--host", type=str, default="localhost", help="Local Weaviate host"
+        )
+        parser_weaviate.add_argument(
+            "--port", type=int, default=8080, help="Local Weaviate HTTP port"
+        )
+        parser_weaviate.add_argument(
+            "--grpc_port", type=int, default=50051, help="Local Weaviate gRPC port"
+        )
+        parser_weaviate.add_argument(
+            "--collections",
+            type=str,
+            help="Collection names to export (comma-separated)",
+        )
+        parser_weaviate.add_argument(
+            "--classes",
+            type=str,
+            help="Deprecated alias for --collections",
+        )
+        parser_weaviate.add_argument(
+            "--batch_size",
+            type=int,
+            help="Batch size for writing parquet files",
+            default=DEFAULT_BATCH_SIZE,
         )
 
     @classmethod
@@ -32,58 +56,237 @@ class ExportWeaviate(ExportVDB):
         set_arg_from_input(
             args,
             "url",
-            "Enter the URL of Weaviate instance: ",
+            "Enter the Weaviate Cloud URL (leave empty for local Weaviate): ",
             str,
+            "",
         )
-        set_arg_from_password(
+        if args.get("url"):
+            set_arg_from_password(
+                args,
+                "api_key",
+                "Enter the Weaviate API key: ",
+                "WEAVIATE_API_KEY",
+            )
+        else:
+            set_arg_from_input(
+                args, "host", "Enter the Weaviate host: ", str, "localhost"
+            )
+            set_arg_from_input(
+                args, "port", "Enter the Weaviate HTTP port: ", int, 8080
+            )
+            set_arg_from_input(
+                args, "grpc_port", "Enter the Weaviate gRPC port: ", int, 50051
+            )
+        set_arg_from_input(
             args,
-            "api_key",
-            "Enter the Weaviate API key: ",
-            "WEAVIATE_API_KEY",
+            "batch_size",
+            (
+                "Enter the batch size for exporting data "
+                f"(default: {DEFAULT_BATCH_SIZE}): "
+            ),
+            int,
+            DEFAULT_BATCH_SIZE,
         )
         weaviate_export = ExportWeaviate(args)
-        weaviate_export.all_classes = list(
-            weaviate_export.client.collections.list_all().keys()
-        )
+        weaviate_export.all_collections = weaviate_export.get_all_index_names()
         set_arg_from_input(
-            weaviate_export.args,
-            "classes",
-            "Enter the name of the classes to export (comma-separated, all will be exported by default): ",
+            args,
+            "collections",
+            (
+                "Enter collection(s) to export "
+                "(comma-separated, hit return to export all): "
+            ),
             str,
-            choices=weaviate_export.all_classes,
+            choices=weaviate_export.all_collections,
         )
         weaviate_export.get_data()
         return weaviate_export
 
-    # Connect to a WCS instance
     def __init__(self, args):
         super().__init__(args)
-        self.client = weaviate.connect_to_wcs(
-            cluster_url=self.args["url"],
-            auth_credentials=weaviate.auth.AuthApiKey(self.args["api_key"]),
+        self.client = self._connect()
+
+    def _connect(self):
+        api_key = self.args.get("api_key")
+        auth_credentials = weaviate.auth.AuthApiKey(api_key) if api_key else None
+        if self.args.get("url"):
+            return weaviate.connect_to_wcs(
+                cluster_url=self.args["url"],
+                auth_credentials=auth_credentials,
+                skip_init_checks=True,
+            )
+        return weaviate.connect_to_local(
+            host=self.args.get("host") or "localhost",
+            port=self.args.get("port") or 8080,
+            grpc_port=self.args.get("grpc_port") or 50051,
+            auth_credentials=auth_credentials,
             skip_init_checks=True,
         )
 
+    def get_all_index_names(self):
+        collections = self.client.collections.list_all()
+        if isinstance(collections, dict):
+            return list(collections.keys())
+        return [
+            getattr(collection, "name", collection)
+            for collection in collections
+        ]
+
     def get_index_names(self):
-        if self.args.get("classes") is None:
-            return self.all_classes
-        else:
-            input_classes = self.args["classes"].split(",")
-            if set(input_classes) - set(self.all_classes):
-                tqdm.write(
-                    f"These classes are not present in the Weaviate instance: {set(input_classes) - set(self.all_classes)}"
-                )
-            return [c for c in self.all_classes if c in input_classes]
+        requested = self.args.get("collections") or self.args.get("classes")
+        if not requested:
+            return self.get_all_index_names()
+        all_collections = set(self.get_all_index_names())
+        input_collections = [
+            name.strip() for name in requested.split(",") if name.strip()
+        ]
+        missing = set(input_collections) - all_collections
+        if missing:
+            tqdm.write(
+                f"These collections are not present in the Weaviate instance: {missing}"
+            )
+        return [name for name in input_collections if name in all_collections]
 
     def get_data(self):
-        # Get all objects of a class
-        index_names = self.get_index_names()
-        for class_name in index_names:
-            collection = self.client.collections.get(class_name)
-            response = collection.aggregate.over_all(total_count=True)
-            print(f"{response.total_count=}")
+        batch_size = self.args.get("batch_size") or DEFAULT_BATCH_SIZE
+        index_metas = {}
+        for collection_name in tqdm(
+            self.get_index_names(), desc="Exporting collections"
+        ):
+            collection = self.client.collections.get(collection_name)
+            vectors_directory = self.create_vec_dir(collection_name)
+            index_config = self._to_jsonable(collection.config.get(simple=False))
+            distance = self._find_distance(index_config) or "cosine"
+            total_count = self._get_total_count(collection)
+            rows: List[Dict[str, Any]] = []
+            exported_count = 0
+            dim = -1
+            vector_columns = set()
 
-            # objects = self.client.query.get(
-            #     wvq.Objects(wvq.Class(class_name)).with_limit(1000)
-            # )
-            # print(objects)
+            for item in tqdm(
+                collection.iterator(include_vector=True),
+                desc=f"Exporting {collection_name} collection",
+                total=total_count if total_count >= 0 else None,
+            ):
+                row, row_vector_columns, row_dim = self._object_to_row(item)
+                rows.append(row)
+                vector_columns.update(row_vector_columns)
+                if dim == -1 and row_dim != -1:
+                    dim = row_dim
+                if len(rows) >= batch_size:
+                    exported_count += self._save_rows_to_parquet(
+                        rows, vectors_directory
+                    )
+                    rows = []
+
+            if rows:
+                exported_count += self._save_rows_to_parquet(rows, vectors_directory)
+
+            namespace_metas = [
+                self.get_namespace_meta(
+                    collection_name,
+                    vectors_directory,
+                    total=total_count if total_count >= 0 else exported_count,
+                    num_vectors_exported=exported_count,
+                    dim=dim,
+                    index_config=index_config,
+                    vector_columns=sorted(vector_columns) or ["vector"],
+                    distance=distance,
+                )
+            ]
+            index_metas[collection_name] = namespace_metas
+
+        self.file_structure.append(os.path.join(self.vdf_directory, "VDF_META.json"))
+        internal_metadata = self.get_basic_vdf_meta(index_metas)
+        meta_text = json.dumps(internal_metadata.model_dump(), indent=4, default=str)
+        tqdm.write(meta_text)
+        with open(os.path.join(self.vdf_directory, "VDF_META.json"), "w") as json_file:
+            json_file.write(meta_text)
+        self.client.close()
+        return True
+
+    def _object_to_row(self, item) -> Tuple[Dict[str, Any], Iterable[str], int]:
+        row = {ID_COLUMN: str(getattr(item, "uuid", ""))}
+        properties = getattr(item, "properties", None) or {}
+        vector = getattr(item, "vector", None)
+        vector_columns = []
+        dim = -1
+
+        if isinstance(vector, dict):
+            for name, value in vector.items():
+                vector_column = "vector" if name in ("default", "") else str(name)
+                row[vector_column] = self._vector_to_list(value)
+                vector_columns.append(vector_column)
+        elif vector is not None:
+            row["vector"] = self._vector_to_list(vector)
+            vector_columns.append("vector")
+
+        for key, value in properties.items():
+            key = str(key)
+            column = f"metadata_{key}" if key in row else key
+            row[column] = self._to_jsonable(value)
+
+        for vector_column in vector_columns:
+            value = row.get(vector_column)
+            if value is not None:
+                dim = len(value)
+                break
+        return row, vector_columns, dim
+
+    def _save_rows_to_parquet(self, rows, vectors_directory):
+        df = pd.DataFrame.from_records(rows)
+        parquet_file = os.path.join(vectors_directory, f"{self.file_ctr}.parquet")
+        df.to_parquet(parquet_file)
+        if not hasattr(self, "parquet_schema"):
+            self.parquet_schema = pq.read_schema(parquet_file)
+        else:
+            self.parquet_schema = pa.unify_schemas(
+                [self.parquet_schema, pq.read_schema(parquet_file)]
+            )
+        self.file_structure.append(parquet_file)
+        self.file_ctr += 1
+        return len(df)
+
+    def _get_total_count(self, collection):
+        try:
+            return collection.aggregate.over_all(total_count=True).total_count
+        except Exception as exc:
+            tqdm.write(f"Could not fetch Weaviate collection count: {exc}")
+            return -1
+
+    def _find_distance(self, value):
+        if isinstance(value, dict):
+            for key, nested_value in value.items():
+                if key in ("distance", "distance_metric"):
+                    if hasattr(nested_value, "value"):
+                        return str(nested_value.value)
+                    return str(nested_value)
+                found = self._find_distance(nested_value)
+                if found:
+                    return found
+        elif isinstance(value, list):
+            for nested_value in value:
+                found = self._find_distance(nested_value)
+                if found:
+                    return found
+        return None
+
+    def _vector_to_list(self, vector):
+        if vector is None:
+            return None
+        if hasattr(vector, "tolist"):
+            return vector.tolist()
+        return list(vector)
+
+    def _to_jsonable(self, value):
+        if hasattr(value, "model_dump"):
+            return self._to_jsonable(value.model_dump())
+        if hasattr(value, "__dict__") and not isinstance(value, type):
+            return self._to_jsonable(vars(value))
+        if isinstance(value, dict):
+            return {str(k): self._to_jsonable(v) for k, v in value.items()}
+        if isinstance(value, (list, tuple, set)):
+            return [self._to_jsonable(v) for v in value]
+        if isinstance(value, (str, int, float, bool)) or value is None:
+            return value
+        return str(value)

--- a/src/vdf_io/import_vdf/weaviate_import.py
+++ b/src/vdf_io/import_vdf/weaviate_import.py
@@ -1,0 +1,306 @@
+import math
+from typing import Any, Dict, List
+from uuid import UUID
+
+import numpy as np
+from tqdm import tqdm
+import weaviate
+from weaviate.classes.config import Configure
+from weaviate.classes.data import DataObject
+from weaviate.util import generate_uuid5
+
+from vdf_io.constants import DEFAULT_BATCH_SIZE, INT_MAX
+from vdf_io.import_vdf.vdf_import_cls import ImportVDB
+from vdf_io.meta_types import NamespaceMeta
+from vdf_io.names import DBNames
+from vdf_io.util import (
+    cleanup_df,
+    divide_into_batches,
+    set_arg_from_input,
+    set_arg_from_password,
+)
+
+
+class ImportWeaviate(ImportVDB):
+    DB_NAME_SLUG = DBNames.WEAVIATE
+
+    @classmethod
+    def make_parser(cls, subparsers):
+        parser_weaviate = subparsers.add_parser(
+            cls.DB_NAME_SLUG, help="Import data to Weaviate"
+        )
+        parser_weaviate.add_argument("--url", type=str, help="URL of Weaviate Cloud")
+        parser_weaviate.add_argument("--api_key", type=str, help="Weaviate API key")
+        parser_weaviate.add_argument(
+            "--host", type=str, default="localhost", help="Local Weaviate host"
+        )
+        parser_weaviate.add_argument(
+            "--port", type=int, default=8080, help="Local Weaviate HTTP port"
+        )
+        parser_weaviate.add_argument(
+            "--grpc_port", type=int, default=50051, help="Local Weaviate gRPC port"
+        )
+
+    @classmethod
+    def import_vdb(cls, args):
+        set_arg_from_input(
+            args,
+            "url",
+            "Enter the Weaviate Cloud URL (leave empty for local Weaviate): ",
+            str,
+            "",
+        )
+        if args.get("url"):
+            set_arg_from_password(
+                args,
+                "api_key",
+                "Enter the Weaviate API key: ",
+                "WEAVIATE_API_KEY",
+            )
+        else:
+            set_arg_from_input(
+                args, "host", "Enter the Weaviate host: ", str, "localhost"
+            )
+            set_arg_from_input(
+                args, "port", "Enter the Weaviate HTTP port: ", int, 8080
+            )
+            set_arg_from_input(
+                args, "grpc_port", "Enter the Weaviate gRPC port: ", int, 50051
+            )
+        weaviate_import = ImportWeaviate(args)
+        try:
+            weaviate_import.upsert_data()
+        finally:
+            weaviate_import.client.close()
+        return weaviate_import
+
+    def __init__(self, args):
+        super().__init__(args)
+        self.client = self._connect()
+
+    def _connect(self):
+        api_key = self.args.get("api_key")
+        auth_credentials = weaviate.auth.AuthApiKey(api_key) if api_key else None
+        if self.args.get("url"):
+            return weaviate.connect_to_wcs(
+                cluster_url=self.args["url"],
+                auth_credentials=auth_credentials,
+                skip_init_checks=True,
+            )
+        return weaviate.connect_to_local(
+            host=self.args.get("host") or "localhost",
+            port=self.args.get("port") or 8080,
+            grpc_port=self.args.get("grpc_port") or 50051,
+            auth_credentials=auth_credentials,
+            skip_init_checks=True,
+        )
+
+    def get_all_index_names(self):
+        collections = self.client.collections.list_all()
+        if isinstance(collections, dict):
+            return list(collections.keys())
+        return [getattr(collection, "name", collection) for collection in collections]
+
+    def upsert_data(self):
+        max_hit = False
+        self.total_imported_count = 0
+        indexes_content: Dict[str, List[NamespaceMeta]] = self.vdf_meta["indexes"]
+        index_names: List[str] = list(indexes_content.keys())
+        if len(index_names) == 0:
+            raise ValueError("No indexes found in VDF_META.json")
+
+        collections = self.get_all_index_names()
+        for index_name, index_meta in tqdm(
+            indexes_content.items(), desc="Importing indexes"
+        ):
+            for namespace_meta in tqdm(index_meta, desc="Importing namespaces"):
+                self.set_dims(namespace_meta, index_name)
+                data_path = namespace_meta["data_path"]
+                final_data_path = self.get_final_data_path(data_path)
+                parquet_files = self.get_parquet_files(final_data_path)
+
+                new_collection_name = index_name + (
+                    f'_{namespace_meta["namespace"]}'
+                    if namespace_meta["namespace"]
+                    else ""
+                )
+                new_collection_name = self.create_new_name(
+                    new_collection_name, collections
+                )
+                vector_column_names, _ = self.get_vector_column_name(
+                    index_name, namespace_meta, multi_vector_supported=True
+                )
+                if new_collection_name not in collections:
+                    self._create_collection(new_collection_name, vector_column_names)
+                    collections.append(new_collection_name)
+
+                collection = self.client.collections.get(new_collection_name)
+                previous_count = self._get_total_count(collection)
+
+                for file in tqdm(parquet_files, desc="Iterating parquet files"):
+                    file_path = self.get_file_path(final_data_path, file)
+                    df = self.read_parquet_progress(
+                        file_path,
+                        max_num_rows=(
+                            (self.args.get("max_num_rows") or INT_MAX)
+                            - self.total_imported_count
+                        ),
+                    )
+                    df = cleanup_df(df)
+                    batch_size = self.args.get("batch_size") or DEFAULT_BATCH_SIZE
+                    for batch in tqdm(
+                        divide_into_batches(df, batch_size),
+                        desc="Importing batches",
+                        total=len(df) // batch_size,
+                    ):
+                        objects = self._build_objects(batch, vector_column_names)
+                        if self.total_imported_count + len(objects) >= (
+                            self.args.get("max_num_rows") or INT_MAX
+                        ):
+                            max_hit = True
+                            objects = objects[
+                                : (self.args.get("max_num_rows") or INT_MAX)
+                                - self.total_imported_count
+                            ]
+                            tqdm.write("Truncating data to limit to max rows")
+                        if len(objects) == 0:
+                            continue
+                        response = collection.data.insert_many(objects)
+                        if getattr(response, "has_errors", False):
+                            tqdm.write(
+                                "Some Weaviate objects failed to import: "
+                                f"{response.errors}"
+                            )
+                        self.total_imported_count += len(objects)
+                        if max_hit:
+                            break
+                    if max_hit:
+                        break
+
+                current_count = self._get_total_count(collection)
+                tqdm.write(
+                    "Imported "
+                    f"{self.total_imported_count} rows into {new_collection_name}"
+                )
+                if previous_count >= 0 and current_count >= 0:
+                    tqdm.write(
+                        "Collection grew from "
+                        f"{previous_count} to {current_count} objects"
+                    )
+                if max_hit:
+                    break
+            if max_hit:
+                break
+        self.args["imported_count"] = self.total_imported_count
+        tqdm.write("Data imported successfully")
+
+    def _create_collection(self, collection_name, vector_column_names):
+        vector_config = self._get_vector_config(vector_column_names)
+        self.client.collections.create(
+            collection_name,
+            vector_config=vector_config,
+        )
+
+    def _get_vector_config(self, vector_column_names):
+        if len(vector_column_names) == 1 and vector_column_names[0] == "vector":
+            return Configure.Vectors.self_provided()
+        return [
+            Configure.Vectors.self_provided(name=vector_column_name)
+            for vector_column_name in vector_column_names
+        ]
+
+    def _build_objects(self, batch, vector_column_names):
+        objects = []
+        skipped = 0
+        for _, row in batch.iterrows():
+            vector = self._get_vector_payload(row, vector_column_names)
+            if vector is None:
+                skipped += 1
+                continue
+            original_id = str(row[self.id_column]) if self.id_column in row else ""
+            uuid = (
+                original_id
+                if self._is_uuid(original_id)
+                else generate_uuid5(original_id)
+            )
+            properties = self._get_properties(
+                row, vector_column_names, original_id, uuid
+            )
+            objects.append(
+                DataObject(
+                    properties=properties,
+                    uuid=uuid,
+                    vector=vector,
+                )
+            )
+        if skipped:
+            tqdm.write(f"Skipped {skipped} rows with empty vector columns")
+        return objects
+
+    def _get_vector_payload(self, row, vector_column_names):
+        vectors = {}
+        for vector_column_name in vector_column_names:
+            if vector_column_name not in row:
+                continue
+            vector = self.extract_vector(row[vector_column_name])
+            if vector is None or len(vector) == 0:
+                continue
+            vectors[vector_column_name] = vector
+        if len(vectors) == 0:
+            return None
+        if len(vectors) == 1 and vector_column_names[0] == "vector":
+            return next(iter(vectors.values()))
+        return vectors
+
+    def _get_properties(self, row, vector_column_names, original_id, uuid):
+        properties = {}
+        for key, value in row.to_dict().items():
+            if key in vector_column_names or key == self.id_column:
+                continue
+            value = self._to_weaviate_value(value)
+            if value is not None:
+                properties[key] = value
+        if original_id != uuid:
+            properties["_vdf_id"] = original_id
+        return properties
+
+    def _to_weaviate_value(self, value):
+        if value is None:
+            return None
+        if isinstance(value, np.generic):
+            value = value.item()
+        if isinstance(value, float) and math.isnan(value):
+            return None
+        if hasattr(value, "isoformat"):
+            return value.isoformat()
+        if isinstance(value, np.ndarray):
+            value = value.tolist()
+        if isinstance(value, dict):
+            converted = {}
+            for k, v in value.items():
+                converted_value = self._to_weaviate_value(v)
+                if converted_value is not None:
+                    converted[str(k)] = converted_value
+            return converted
+        if isinstance(value, (list, tuple)):
+            return [
+                converted
+                for converted in (self._to_weaviate_value(v) for v in value)
+                if converted is not None
+            ]
+        if isinstance(value, (str, int, float, bool)):
+            return value
+        return str(value)
+
+    def _get_total_count(self, collection):
+        try:
+            return collection.aggregate.over_all(total_count=True).total_count
+        except Exception:
+            return -1
+
+    def _is_uuid(self, value):
+        try:
+            UUID(value)
+            return True
+        except (TypeError, ValueError):
+            return False

--- a/src/vdf_io/import_vdf/weaviate_import.py
+++ b/src/vdf_io/import_vdf/weaviate_import.py
@@ -1,5 +1,5 @@
 import math
-from typing import Any, Dict, List
+from typing import Dict, List
 from uuid import UUID
 
 import numpy as np


### PR DESCRIPTION
Closes #74.

## Summary
- complete the Weaviate exporter so it writes VDF parquet files and VDF_META.json
- add a Weaviate importer for VDF datasets, including self-provided vectors and named-vector collections
- support local Weaviate and Weaviate Cloud connection options

## Verification
- python -m py_compile src/vdf_io/export_vdf/weaviate_export.py src/vdf_io/import_vdf/weaviate_import.py
- imported both new connector classes with PYTHONPATH=src
- exercised parser setup and helper conversions for Weaviate rows/DataObject payloads

Note: I did not run an end-to-end Weaviate server import/export in this environment.